### PR TITLE
Support for memory-based FBX streams

### DIFF
--- a/include/ozz/animation/offline/fbx/fbx_base.h
+++ b/include/ozz/animation/offline/fbx/fbx_base.h
@@ -144,10 +144,13 @@ class FbxSystemConverter {
 class FbxSceneLoader {
  public:
   // Loads the scene that can then be obtained with scene() function.
+  // _stream is optional. If provided it will be used instead of File IO.
+  // _filename/_password is still required for logging and reading.
    FbxSceneLoader(const char* _filename,
                   const char* _password,
                   const FbxManagerInstance& _manager,
-                  const FbxDefaultIOSettings& _io_settings);
+                  const FbxDefaultIOSettings& _io_settings,
+                  FbxStream* _stream = NULL);
   ~FbxSceneLoader();
 
   // Returns a valid scene if fbx import was successful, NULL otherwise.

--- a/include/ozz/animation/offline/fbx/fbx_base.h
+++ b/include/ozz/animation/offline/fbx/fbx_base.h
@@ -144,13 +144,16 @@ class FbxSystemConverter {
 class FbxSceneLoader {
  public:
   // Loads the scene that can then be obtained with scene() function.
-  // _stream is optional. If provided it will be used instead of File IO.
-  // _filename/_password is still required for logging and reading.
    FbxSceneLoader(const char* _filename,
                   const char* _password,
                   const FbxManagerInstance& _manager,
-                  const FbxDefaultIOSettings& _io_settings,
-                  FbxStream* _stream = NULL);
+                  const FbxDefaultIOSettings& _io_settings);
+
+   FbxSceneLoader(FbxStream* _stream,
+                  const char* _password,
+                  const FbxManagerInstance& _manager,
+                  const FbxDefaultIOSettings& _io_settings);
+
   ~FbxSceneLoader();
 
   // Returns a valid scene if fbx import was successful, NULL otherwise.
@@ -164,6 +167,12 @@ class FbxSceneLoader {
   }
 
 private:
+
+  void import_scene(FbxImporter* _importer,
+                  const bool _initialized,
+                  const char* _password,
+                  const FbxManagerInstance& _manager,
+                  const FbxDefaultIOSettings& _io_settings);  
 
   // Scene instance that was loaded from the file.
   FbxScene* scene_;

--- a/src/animation/offline/fbx/fbx_base.cc
+++ b/src/animation/offline/fbx/fbx_base.cc
@@ -90,17 +90,38 @@ FbxSkeletonIOSettings::FbxSkeletonIOSettings(const FbxManagerInstance& _manager)
 FbxSceneLoader::FbxSceneLoader(const char* _filename,
                                const char* _password,
                                const FbxManagerInstance& _manager,
-                               const FbxDefaultIOSettings& _io_settings,
-                               FbxStream* _stream)
+                               const FbxDefaultIOSettings& _io_settings)
     : scene_(NULL),
-      converter_(NULL) {
+      converter_(NULL)
+{
   // Create an importer.
   FbxImporter* importer = FbxImporter::Create(_manager,"ozz importer");
+  const bool initialized = importer->Initialize(_filename, -1, _io_settings);
+  import_scene(importer, initialized, _password, _manager, _io_settings);
+}
 
-  // Initialize the importer by providing a filename. Use all available plugins.
-  const bool initialized = _stream ?
-    importer->Initialize(_stream, NULL, -1, _io_settings) :
-    importer->Initialize(_filename, -1, _io_settings);
+
+FbxSceneLoader::FbxSceneLoader(FbxStream* _stream,
+                               const char* _password,
+                               const FbxManagerInstance& _manager,
+                               const FbxDefaultIOSettings& _io_settings)
+    : scene_(NULL),
+      converter_(NULL)
+{
+  // Create an importer.
+  FbxImporter* importer = FbxImporter::Create(_manager,"ozz importer");
+  const bool initialized = importer->Initialize(_stream, NULL, -1, _io_settings);
+  import_scene(importer, initialized, _password, _manager, _io_settings);
+}
+
+void FbxSceneLoader::import_scene(FbxImporter* _importer,
+                               const bool _initialized,
+                               const char* _password,
+                               const FbxManagerInstance& _manager,
+                               const FbxDefaultIOSettings& _io_settings)
+{
+  FbxImporter* importer = _importer;
+  const bool initialized = _initialized;
 
   // Get the version of the FBX file format.
   int major, minor, revision;
@@ -114,14 +135,14 @@ FbxSceneLoader::FbxSceneLoader(const char* _filename,
 
     if (importer->GetStatus().GetCode() == FbxStatus::eInvalidFileVersion)
     {
-      ozz::log::Err() << "FBX version of " << _filename << " is " <<
+      ozz::log::Err() << "FBX version of file is " <<
         major << "." << minor<< "." << revision << "." << std::endl;
     }
   }
 
   if (initialized) {
     if ( importer->IsFBX()) {
-      ozz::log::Log() << "FBX version of " << _filename << " is " <<
+      ozz::log::Log() << "FBX version of file is " <<
         major << "." << minor<< "." << revision << "." << std::endl;
     }
 

--- a/src/animation/offline/fbx/fbx_base.cc
+++ b/src/animation/offline/fbx/fbx_base.cc
@@ -90,14 +90,17 @@ FbxSkeletonIOSettings::FbxSkeletonIOSettings(const FbxManagerInstance& _manager)
 FbxSceneLoader::FbxSceneLoader(const char* _filename,
                                const char* _password,
                                const FbxManagerInstance& _manager,
-                               const FbxDefaultIOSettings& _io_settings)
+                               const FbxDefaultIOSettings& _io_settings,
+                               FbxStream* _stream)
     : scene_(NULL),
       converter_(NULL) {
   // Create an importer.
   FbxImporter* importer = FbxImporter::Create(_manager,"ozz importer");
 
   // Initialize the importer by providing a filename. Use all available plugins.
-  const bool initialized = importer->Initialize(_filename, -1, _io_settings);
+  const bool initialized = _stream ?
+    importer->Initialize(_stream, NULL, -1, _io_settings) :
+    importer->Initialize(_filename, -1, _io_settings);
 
   // Get the version of the FBX file format.
   int major, minor, revision;

--- a/src_fused/ozz_animation_fbx.cc
+++ b/src_fused/ozz_animation_fbx.cc
@@ -614,12 +614,36 @@ FbxSceneLoader::FbxSceneLoader(const char* _filename,
                                const FbxManagerInstance& _manager,
                                const FbxDefaultIOSettings& _io_settings)
     : scene_(NULL),
-      converter_(NULL) {
+      converter_(NULL)
+{
   // Create an importer.
   FbxImporter* importer = FbxImporter::Create(_manager,"ozz importer");
-
-  // Initialize the importer by providing a filename. Use all available plugins.
   const bool initialized = importer->Initialize(_filename, -1, _io_settings);
+  import_scene(importer, initialized, _password, _manager, _io_settings);
+}
+
+
+FbxSceneLoader::FbxSceneLoader(FbxStream* _stream,
+                               const char* _password,
+                               const FbxManagerInstance& _manager,
+                               const FbxDefaultIOSettings& _io_settings)
+    : scene_(NULL),
+      converter_(NULL)
+{
+  // Create an importer.
+  FbxImporter* importer = FbxImporter::Create(_manager,"ozz importer");
+  const bool initialized = importer->Initialize(_stream, NULL, -1, _io_settings);
+  import_scene(importer, initialized, _password, _manager, _io_settings);
+}
+
+void FbxSceneLoader::import_scene(FbxImporter* _importer,
+                               const bool _initialized,
+                               const char* _password,
+                               const FbxManagerInstance& _manager,
+                               const FbxDefaultIOSettings& _io_settings)
+{
+  FbxImporter* importer = _importer;
+  const bool initialized = _initialized;
 
   // Get the version of the FBX file format.
   int major, minor, revision;
@@ -633,14 +657,14 @@ FbxSceneLoader::FbxSceneLoader(const char* _filename,
 
     if (importer->GetStatus().GetCode() == FbxStatus::eInvalidFileVersion)
     {
-      ozz::log::Err() << "FBX version of " << _filename << " is " <<
+      ozz::log::Err() << "FBX version of file is " <<
         major << "." << minor<< "." << revision << "." << std::endl;
     }
   }
 
   if (initialized) {
     if ( importer->IsFBX()) {
-      ozz::log::Log() << "FBX version of " << _filename << " is " <<
+      ozz::log::Log() << "FBX version of file is " <<
         major << "." << minor<< "." << revision << "." << std::endl;
     }
 


### PR DESCRIPTION
I use VFS in my code and it's very convenient to provide virtual streams instead of using File I/O. This commit allows importing FBX files from such streams.