### PR TITLE
Minor build system tweak that allows importing the whole project as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 9)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
 
-set(ozz_root_dir ${CMAKE_CURRENT_SOURCE_DIR})
-
 # Add project build options
 set(ozz_build_fbx ON CACHE BOOL "Build Fbx pipeline (Requires Fbx SDK)")
 set(ozz_build_samples ON CACHE BOOL "Build samples")
@@ -24,10 +22,10 @@ set(ozz_run_tests_headless ON CACHE BOOL "Run samples without rendering (used fo
 set(ozz_sample_testing_loops "20" CACHE INT "Number of loops while running sample tests (used for unit tests)")
 
 # Include ozz cmake parameters and scripts
-include(${ozz_root_dir}/build-utils/cmake/compiler_settings.cmake)
-include(${ozz_root_dir}/build-utils/cmake/package_settings.cmake)
-include(${ozz_root_dir}/build-utils/cmake/fuse_target.cmake)
-include(${ozz_root_dir}/build-utils/cmake/clang_format.cmake)
+include(${PROJECT_SOURCE_DIR}/build-utils/cmake/compiler_settings.cmake)
+include(${PROJECT_SOURCE_DIR}/build-utils/cmake/package_settings.cmake)
+include(${PROJECT_SOURCE_DIR}/build-utils/cmake/fuse_target.cmake)
+include(${PROJECT_SOURCE_DIR}/build-utils/cmake/clang_format.cmake)
 
 # Enables unit tests only
 if(ozz_build_tests)
@@ -35,7 +33,7 @@ if(ozz_build_tests)
 endif()
 
 # Configure CMake module path
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ozz_root_dir}/build-utils/cmake/modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/build-utils/cmake/modules/")
 
 # Detects Fbx SDK, required to build Fbx pipeline.
 if(ozz_build_fbx)
@@ -48,7 +46,7 @@ if(ozz_build_fbx)
 endif()
 
 # Locates media directory.
-set(ozz_media_directory "${ozz_root_dir}/media")
+set(ozz_media_directory "${PROJECT_SOURCE_DIR}/media")
 
 # Creates temporary directory for tests inputs/outputs.
 set(ozz_temp_directory ${CMAKE_BINARY_DIR}/temp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 9)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
 
+set(ozz_root_dir ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Add project build options
 set(ozz_build_fbx ON CACHE BOOL "Build Fbx pipeline (Requires Fbx SDK)")
 set(ozz_build_samples ON CACHE BOOL "Build samples")
@@ -22,10 +24,10 @@ set(ozz_run_tests_headless ON CACHE BOOL "Run samples without rendering (used fo
 set(ozz_sample_testing_loops "20" CACHE INT "Number of loops while running sample tests (used for unit tests)")
 
 # Include ozz cmake parameters and scripts
-include(build-utils/cmake/compiler_settings.cmake)
-include(build-utils/cmake/package_settings.cmake)
-include(build-utils/cmake/fuse_target.cmake)
-include(build-utils/cmake/clang_format.cmake)
+include(${ozz_root_dir}/build-utils/cmake/compiler_settings.cmake)
+include(${ozz_root_dir}/build-utils/cmake/package_settings.cmake)
+include(${ozz_root_dir}/build-utils/cmake/fuse_target.cmake)
+include(${ozz_root_dir}/build-utils/cmake/clang_format.cmake)
 
 # Enables unit tests only
 if(ozz_build_tests)
@@ -33,7 +35,7 @@ if(ozz_build_tests)
 endif()
 
 # Configure CMake module path
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build-utils/cmake/modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ozz_root_dir}/build-utils/cmake/modules/")
 
 # Detects Fbx SDK, required to build Fbx pipeline.
 if(ozz_build_fbx)
@@ -46,7 +48,7 @@ if(ozz_build_fbx)
 endif()
 
 # Locates media directory.
-set(ozz_media_directory "${CMAKE_SOURCE_DIR}/media")
+set(ozz_media_directory "${ozz_root_dir}/media")
 
 # Creates temporary directory for tests inputs/outputs.
 set(ozz_temp_directory ${CMAKE_BINARY_DIR}/temp)

--- a/build-utils/cmake/compiler_settings.cmake
+++ b/build-utils/cmake/compiler_settings.cmake
@@ -78,7 +78,7 @@ if(MSVC)
   string(REGEX REPLACE " /EH.*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REGEX REPLACE " /EH.*" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS _HAS_EXCEPTIONS=0)
-  
+
   # Adds support for multiple processes builds
   set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "/MP")
 
@@ -87,11 +87,11 @@ if(MSVC)
   foreach(flag ${cxx_all_flags})
     # Set the warning level to W4
     string(REGEX REPLACE "/W3" "/W4" ${flag} "${${flag}}")
-    
+
     # Prefers static lining with runtime libraries, to ease installation
     string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
 
-	# Prefers /Ox (full optimization) to /O2 (maximize speed)
+    # Prefers /Ox (full optimization) to /O2 (maximize speed)
     string(REGEX REPLACE "/O2" "/Ox" ${flag} "${${flag}}")
   endforeach()
 
@@ -197,7 +197,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ".")
 
 #-------------------------------
 # Set a postfix for output files
-set(CMAKE_DEBUG_POSTFIX "_d")
-set(CMAKE_RELEASE_POSTFIX "_r")
-set(CMAKE_MINSIZEREL_POSTFIX "_rs")
-set(CMAKE_RELWITHDEBINFO_POSTFIX "_rd")
+set(ozz_override_configuration_postfixes CACHE ON "Add custom postfixes for output files")
+if(ozz_override_configuration_postfixes)
+    set(CMAKE_DEBUG_POSTFIX "_d")
+    set(CMAKE_RELEASE_POSTFIX "_r")
+    set(CMAKE_MINSIZEREL_POSTFIX "_rs")
+    set(CMAKE_RELWITHDEBINFO_POSTFIX "_rd")
+endif()

--- a/build-utils/cmake/fuse_target.cmake
+++ b/build-utils/cmake/fuse_target.cmake
@@ -4,7 +4,7 @@
 function(fuse_target _target_name)
 
   set(output_file_name "${_target_name}.cc")
-  set(output_file "${CMAKE_SOURCE_DIR}/src_fused/${output_file_name}")
+  set(output_file "${ozz_root_dir}/src_fused/${output_file_name}")
 
   # Get all target sources.
   get_property(target_source_files TARGET ${_target_name} PROPERTY SOURCES)
@@ -12,8 +12,8 @@ function(fuse_target _target_name)
   add_custom_command(
     OUTPUT "${output_file}"
     DEPENDS "${target_source_files}"
-            "${CMAKE_SOURCE_DIR}/build-utils/cmake/fuse_target_script.cmake"
-    COMMAND ${CMAKE_COMMAND} -Dozz_fuse_output_file="${output_file}" -Dozz_target_source_files="${target_source_files}" -Dozz_fuse_target_dir="${CMAKE_CURRENT_LIST_DIR}" -Dozz_fuse_src_dir="${CMAKE_SOURCE_DIR}" -P "${CMAKE_SOURCE_DIR}/build-utils/cmake/fuse_target_script.cmake")
+            "${ozz_root_dir}/build-utils/cmake/fuse_target_script.cmake"
+    COMMAND ${CMAKE_COMMAND} -Dozz_fuse_output_file="${output_file}" -Dozz_target_source_files="${target_source_files}" -Dozz_fuse_target_dir="${CMAKE_CURRENT_LIST_DIR}" -Dozz_fuse_src_dir="${ozz_root_dir}" -P "${ozz_root_dir}/build-utils/cmake/fuse_target_script.cmake")
 
   add_custom_target(BUILD_FUSE_${_target_name} ALL DEPENDS "${output_file}")
   set_target_properties(BUILD_FUSE_${_target_name} PROPERTIES FOLDER "ozz/fuse")

--- a/build-utils/cmake/fuse_target.cmake
+++ b/build-utils/cmake/fuse_target.cmake
@@ -4,7 +4,7 @@
 function(fuse_target _target_name)
 
   set(output_file_name "${_target_name}.cc")
-  set(output_file "${ozz_root_dir}/src_fused/${output_file_name}")
+  set(output_file "${PROJECT_SOURCE_DIR}/src_fused/${output_file_name}")
 
   # Get all target sources.
   get_property(target_source_files TARGET ${_target_name} PROPERTY SOURCES)
@@ -12,8 +12,8 @@ function(fuse_target _target_name)
   add_custom_command(
     OUTPUT "${output_file}"
     DEPENDS "${target_source_files}"
-            "${ozz_root_dir}/build-utils/cmake/fuse_target_script.cmake"
-    COMMAND ${CMAKE_COMMAND} -Dozz_fuse_output_file="${output_file}" -Dozz_target_source_files="${target_source_files}" -Dozz_fuse_target_dir="${CMAKE_CURRENT_LIST_DIR}" -Dozz_fuse_src_dir="${ozz_root_dir}" -P "${ozz_root_dir}/build-utils/cmake/fuse_target_script.cmake")
+            "${PROJECT_SOURCE_DIR}/build-utils/cmake/fuse_target_script.cmake"
+    COMMAND ${CMAKE_COMMAND} -Dozz_fuse_output_file="${output_file}" -Dozz_target_source_files="${target_source_files}" -Dozz_fuse_target_dir="${CMAKE_CURRENT_LIST_DIR}" -Dozz_fuse_src_dir="${PROJECT_SOURCE_DIR}" -P "${PROJECT_SOURCE_DIR}/build-utils/cmake/fuse_target_script.cmake")
 
   add_custom_target(BUILD_FUSE_${_target_name} ALL DEPENDS "${output_file}")
   set_target_properties(BUILD_FUSE_${_target_name} PROPERTIES FOLDER "ozz/fuse")

--- a/extern/glfw/CMakeLists.txt
+++ b/extern/glfw/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(lib)
 # Buils Win32 specific files and options
 if(WIN32)
   include_directories(lib/win32)
-  set(specific_file_list 
+  set(specific_file_list
     lib/win32/platform.h
     lib/win32/win32_dllmain.c
     lib/win32/win32_enable.c
@@ -22,7 +22,7 @@ if(UNIX AND NOT APPLE)
   if(X11_FOUND)
     include_directories(lib/x11)
     include_directories(${X11_INCLUDE_DIR})
-    set(specific_file_list 
+    set(specific_file_list
       lib/x11/platform.h
       lib/x11/x11_enable.c
       lib/x11/x11_fullscreen.c
@@ -54,11 +54,11 @@ if(UNIX AND APPLE)
     lib/cocoa/cocoa_window.m)
   # Treats .m files as C files.
   set_source_files_properties(${specific_objc_file_list} PROPERTIES LANGUAGE C)
-  
+
   # Disables warnings in glfw.
   set_source_files_properties(${specific_objc_file_list} PROPERTIES COMPILE_FLAGS
     "-Wno-deprecated-declarations -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-int-conversion")
-  
+
   # Appends other c files
   set(specific_file_list
     ${specific_objc_file_list}
@@ -66,7 +66,7 @@ if(UNIX AND APPLE)
     lib/cocoa/platform.h)
 endif()
 
-add_library(glfw
+add_library(glfw STATIC
   include/GL/glfw.h
   include/GL/glext.h
   lib/enable.c

--- a/samples/framework/CMakeLists.txt
+++ b/samples/framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${ozz_root_dir}/extern/glfw/include)
 
-add_library(sample_framework
+add_library(sample_framework STATIC
   application.h
   application.cc
   imgui.h

--- a/samples/framework/CMakeLists.txt
+++ b/samples/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${CMAKE_SOURCE_DIR}/extern/glfw/include)
+include_directories(${ozz_root_dir}/extern/glfw/include)
 
 add_library(sample_framework
   application.h
@@ -31,8 +31,8 @@ if(NOT EMSCRIPTEN)
   find_package(OpenGL REQUIRED)
 
   include_directories(${OPENGL_INCLUDE_DIR})
-  
-  add_subdirectory(${CMAKE_SOURCE_DIR}/extern/glfw glfw)
+
+  add_subdirectory(${ozz_root_dir}/extern/glfw glfw)
 
   target_link_libraries(sample_framework
     ${OPENGL_LIBRARIES}
@@ -51,5 +51,5 @@ endif()
 
 set_target_properties(sample_framework
   PROPERTIES FOLDER "samples")
-  
+
 add_subdirectory(tools)

--- a/samples/framework/CMakeLists.txt
+++ b/samples/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${ozz_root_dir}/extern/glfw/include)
+include_directories(${PROJECT_SOURCE_DIR}/extern/glfw/include)
 
 add_library(sample_framework STATIC
   application.h
@@ -32,7 +32,7 @@ if(NOT EMSCRIPTEN)
 
   include_directories(${OPENGL_INCLUDE_DIR})
 
-  add_subdirectory(${ozz_root_dir}/extern/glfw glfw)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/extern/glfw glfw)
 
   target_link_libraries(sample_framework
     ${OPENGL_LIBRARIES}

--- a/samples/framework/tools/CMakeLists.txt
+++ b/samples/framework/tools/CMakeLists.txt
@@ -5,8 +5,8 @@ if(ozz_build_fbx)
   # share meshes with thte sample framework
   add_executable(sample_fbx2mesh
     fbx2mesh.cc
-    ${ozz_root_dir}/samples/framework/mesh.cc
-    ${ozz_root_dir}/samples/framework/mesh.h)
+    ${PROJECT_SOURCE_DIR}/samples/framework/mesh.cc
+    ${PROJECT_SOURCE_DIR}/samples/framework/mesh.h)
   target_link_libraries(sample_fbx2mesh
     ozz_animation_fbx
     ozz_animation_offline

--- a/samples/framework/tools/CMakeLists.txt
+++ b/samples/framework/tools/CMakeLists.txt
@@ -5,8 +5,8 @@ if(ozz_build_fbx)
   # share meshes with thte sample framework
   add_executable(sample_fbx2mesh
     fbx2mesh.cc
-    ${CMAKE_SOURCE_DIR}/samples/framework/mesh.cc
-    ${CMAKE_SOURCE_DIR}/samples/framework/mesh.h)
+    ${ozz_root_dir}/samples/framework/mesh.cc
+    ${ozz_root_dir}/samples/framework/mesh.h)
   target_link_libraries(sample_fbx2mesh
     ozz_animation_fbx
     ozz_animation_offline
@@ -15,7 +15,7 @@ if(ozz_build_fbx)
     ozz_base)
   set_target_properties(sample_fbx2mesh
     PROPERTIES FOLDER "samples/tools")
-  
+
   install(TARGETS sample_fbx2mesh DESTINATION bin/samples/tools)
 
   add_custom_command(

--- a/src/animation/offline/CMakeLists.txt
+++ b/src/animation/offline/CMakeLists.txt
@@ -1,19 +1,19 @@
 add_library(ozz_animation_offline STATIC
-  ${ozz_root_dir}/include/ozz/animation/offline/raw_animation.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/raw_animation.h
   raw_animation.cc
   raw_animation_archive.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/raw_animation_utils.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/raw_animation_utils.h
   raw_animation_utils.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/animation_builder.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/animation_builder.h
   animation_builder.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/animation_optimizer.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/animation_optimizer.h
   animation_optimizer.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/additive_animation_builder.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/additive_animation_builder.h
   additive_animation_builder.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/raw_skeleton.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/raw_skeleton.h
   raw_skeleton.cc
   raw_skeleton_archive.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/skeleton_builder.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/skeleton_builder.h
   skeleton_builder.cc)
 set_target_properties(ozz_animation_offline PROPERTIES FOLDER "ozz")
 

--- a/src/animation/offline/CMakeLists.txt
+++ b/src/animation/offline/CMakeLists.txt
@@ -1,19 +1,19 @@
 add_library(ozz_animation_offline
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/raw_animation.h
+  ${ozz_root_dir}/include/ozz/animation/offline/raw_animation.h
   raw_animation.cc
   raw_animation_archive.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/raw_animation_utils.h
+  ${ozz_root_dir}/include/ozz/animation/offline/raw_animation_utils.h
   raw_animation_utils.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/animation_builder.h
+  ${ozz_root_dir}/include/ozz/animation/offline/animation_builder.h
   animation_builder.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/animation_optimizer.h
+  ${ozz_root_dir}/include/ozz/animation/offline/animation_optimizer.h
   animation_optimizer.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/additive_animation_builder.h
+  ${ozz_root_dir}/include/ozz/animation/offline/additive_animation_builder.h
   additive_animation_builder.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/raw_skeleton.h
+  ${ozz_root_dir}/include/ozz/animation/offline/raw_skeleton.h
   raw_skeleton.cc
   raw_skeleton_archive.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/skeleton_builder.h
+  ${ozz_root_dir}/include/ozz/animation/offline/skeleton_builder.h
   skeleton_builder.cc)
 set_target_properties(ozz_animation_offline PROPERTIES FOLDER "ozz")
 

--- a/src/animation/offline/CMakeLists.txt
+++ b/src/animation/offline/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_animation_offline
+add_library(ozz_animation_offline STATIC
   ${ozz_root_dir}/include/ozz/animation/offline/raw_animation.h
   raw_animation.cc
   raw_animation_archive.cc

--- a/src/animation/offline/fbx/CMakeLists.txt
+++ b/src/animation/offline/fbx/CMakeLists.txt
@@ -5,11 +5,11 @@ endif()
 include_directories(${FBX_INCLUDE_DIRS})
 
 add_library(ozz_animation_fbx STATIC
-  ${ozz_root_dir}/include/ozz/animation/offline/fbx/fbx.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx.h
   fbx.cc
   fbx_animation.h
   fbx_animation.cc
-  ${ozz_root_dir}/include/ozz/animation/offline/fbx/fbx_base.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx_base.h
   fbx_base.cc
   fbx_skeleton.h
   fbx_skeleton.cc)

--- a/src/animation/offline/fbx/CMakeLists.txt
+++ b/src/animation/offline/fbx/CMakeLists.txt
@@ -5,11 +5,11 @@ endif()
 include_directories(${FBX_INCLUDE_DIRS})
 
 add_library(ozz_animation_fbx
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx.h
+  ${ozz_root_dir}/include/ozz/animation/offline/fbx/fbx.h
   fbx.cc
   fbx_animation.h
   fbx_animation.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx_base.h
+  ${ozz_root_dir}/include/ozz/animation/offline/fbx/fbx_base.h
   fbx_base.cc
   fbx_skeleton.h
   fbx_skeleton.cc)
@@ -63,7 +63,7 @@ set(skeletons
   "/collada/seymour.dae\;/bin/seymour_skeleton.ozz")
 
 foreach(line ${skeletons})
-  list(GET line 0 src) 
+  list(GET line 0 src)
   list(GET line 1 dest)
 
   list(APPEND bin_skeletons ${ozz_media_directory}${dest})

--- a/src/animation/offline/fbx/CMakeLists.txt
+++ b/src/animation/offline/fbx/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 include_directories(${FBX_INCLUDE_DIRS})
 
-add_library(ozz_animation_fbx
+add_library(ozz_animation_fbx STATIC
   ${ozz_root_dir}/include/ozz/animation/offline/fbx/fbx.h
   fbx.cc
   fbx_animation.h

--- a/src/animation/offline/tools/CMakeLists.txt
+++ b/src/animation/offline/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(ozz_animation_offline_skel_tools STATIC
-  ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2skel.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/tools/convert2skel.h
   convert2skel.cc)
 set_target_properties(ozz_animation_offline_skel_tools
   PROPERTIES FOLDER "ozz/tools")
@@ -9,7 +9,7 @@ install(TARGETS ozz_animation_offline_skel_tools DESTINATION lib)
 fuse_target("ozz_animation_offline_skel_tools")
 
 add_library(ozz_animation_offline_anim_tools STATIC
-  ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2anim.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/tools/convert2anim.h
   convert2anim.cc)
 set_target_properties(ozz_animation_offline_anim_tools
   PROPERTIES FOLDER "ozz/tools")

--- a/src/animation/offline/tools/CMakeLists.txt
+++ b/src/animation/offline/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_animation_offline_skel_tools
+add_library(ozz_animation_offline_skel_tools STATIC
   ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2skel.h
   convert2skel.cc)
 set_target_properties(ozz_animation_offline_skel_tools
@@ -8,7 +8,7 @@ install(TARGETS ozz_animation_offline_skel_tools DESTINATION lib)
 
 fuse_target("ozz_animation_offline_skel_tools")
 
-add_library(ozz_animation_offline_anim_tools
+add_library(ozz_animation_offline_anim_tools STATIC
   ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2anim.h
   convert2anim.cc)
 set_target_properties(ozz_animation_offline_anim_tools

--- a/src/animation/offline/tools/CMakeLists.txt
+++ b/src/animation/offline/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(ozz_animation_offline_skel_tools
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/tools/convert2skel.h
+  ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2skel.h
   convert2skel.cc)
 set_target_properties(ozz_animation_offline_skel_tools
   PROPERTIES FOLDER "ozz/tools")
@@ -9,7 +9,7 @@ install(TARGETS ozz_animation_offline_skel_tools DESTINATION lib)
 fuse_target("ozz_animation_offline_skel_tools")
 
 add_library(ozz_animation_offline_anim_tools
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/offline/tools/convert2anim.h
+  ${ozz_root_dir}/include/ozz/animation/offline/tools/convert2anim.h
   convert2anim.cc)
 set_target_properties(ozz_animation_offline_anim_tools
   PROPERTIES FOLDER "ozz/tools")

--- a/src/animation/runtime/CMakeLists.txt
+++ b/src/animation/runtime/CMakeLists.txt
@@ -1,16 +1,16 @@
 add_library(ozz_animation
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/animation.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/animation.h
   animation.cc
   animation_keyframe.h
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/blending_job.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/blending_job.h
   blending_job.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/local_to_model_job.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/local_to_model_job.h
   local_to_model_job.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/sampling_job.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/sampling_job.h
   sampling_job.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/skeleton.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/skeleton.h
   skeleton.cc
-  ${CMAKE_SOURCE_DIR}/include/ozz/animation/runtime/skeleton_utils.h
+  ${ozz_root_dir}/include/ozz/animation/runtime/skeleton_utils.h
   skeleton_utils.cc)
 set_target_properties(ozz_animation
   PROPERTIES FOLDER "ozz")

--- a/src/animation/runtime/CMakeLists.txt
+++ b/src/animation/runtime/CMakeLists.txt
@@ -1,16 +1,16 @@
 add_library(ozz_animation STATIC
-  ${ozz_root_dir}/include/ozz/animation/runtime/animation.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/animation.h
   animation.cc
   animation_keyframe.h
-  ${ozz_root_dir}/include/ozz/animation/runtime/blending_job.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/blending_job.h
   blending_job.cc
-  ${ozz_root_dir}/include/ozz/animation/runtime/local_to_model_job.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/local_to_model_job.h
   local_to_model_job.cc
-  ${ozz_root_dir}/include/ozz/animation/runtime/sampling_job.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/sampling_job.h
   sampling_job.cc
-  ${ozz_root_dir}/include/ozz/animation/runtime/skeleton.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/skeleton.h
   skeleton.cc
-  ${ozz_root_dir}/include/ozz/animation/runtime/skeleton_utils.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/skeleton_utils.h
   skeleton_utils.cc)
 set_target_properties(ozz_animation
   PROPERTIES FOLDER "ozz")

--- a/src/animation/runtime/CMakeLists.txt
+++ b/src/animation/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_animation
+add_library(ozz_animation STATIC
   ${ozz_root_dir}/include/ozz/animation/runtime/animation.h
   animation.cc
   animation_keyframe.h

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_base
+add_library(ozz_base STATIC
   ../../include/ozz/base/endianness.h
   ../../include/ozz/base/gtest_helper.h
   ../../include/ozz/base/memory/allocator.h

--- a/src/geometry/runtime/CMakeLists.txt
+++ b/src/geometry/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(ozz_geometry STATIC
-  ${ozz_root_dir}/include/ozz/geometry/runtime/skinning_job.h
+  ${PROJECT_SOURCE_DIR}/include/ozz/geometry/runtime/skinning_job.h
   skinning_job.cc)
 set_target_properties(ozz_geometry
   PROPERTIES FOLDER "ozz")

--- a/src/geometry/runtime/CMakeLists.txt
+++ b/src/geometry/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_geometry
+add_library(ozz_geometry STATIC
   ${ozz_root_dir}/include/ozz/geometry/runtime/skinning_job.h
   skinning_job.cc)
 set_target_properties(ozz_geometry

--- a/src/geometry/runtime/CMakeLists.txt
+++ b/src/geometry/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(ozz_geometry
-  ${CMAKE_SOURCE_DIR}/include/ozz/geometry/runtime/skinning_job.h
+  ${ozz_root_dir}/include/ozz/geometry/runtime/skinning_job.h
   skinning_job.cc)
 set_target_properties(ozz_geometry
   PROPERTIES FOLDER "ozz")

--- a/src/options/CMakeLists.txt
+++ b/src/options/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_options
+add_library(ozz_options STATIC
   ../../include/ozz/options/options.h
   options.cc)
 set_target_properties(ozz_options PROPERTIES FOLDER "ozz")


### PR DESCRIPTION
Hello,

I've made some minor fixes that allows importing the whole ozz project as a cmake subdirectory.

Changes are pretty trivial - they just retarget all relevant source directories from the global source directory to the directory where ozz currently lives.

Thanks,
Kirill.

EDIT: I've added another commit, that fixes cmake issue when it switches from static to dynamic linking for some reason.