### PR TITLE
Make ozz work with vs2017 and fbx2019

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,8 +186,8 @@ install:
     sudo wget $FBX_DOWNLOAD -O fbx.tar.gz;
     sudo tar -xf "fbx.tar.gz";
     (yes yes | sudo ./*_fbxsdk_linux /usr/local) || true;
-    sudo chmod -R 755 /usr/local/lib
-    sudo chmod -R 755 /usr/local/include
+    sudo chmod -R 755 /usr/local/lib;
+    sudo chmod -R 755 /usr/local/include;
     cd ..;
   fi
 - if [[ $TRAVIS_OS_NAME == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,11 @@ install:
     cd ..;
   fi
 - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    FBX_DOWNLOAD=${fbx_download:-"http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_clang_mac.pkg.tgz"}
+    if [ -z "$fbx_download" ]; then
+      FBX_DOWNLOAD="http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_clang_mac.pkg.tgz";
+    else
+      FBX_DOWNLOAD="$fbx_download";
+    fi;
     mkdir fbx;
     cd fbx;
     sudo wget $FBX_DOWNLOAD -O fbx.tgz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,15 @@ matrix:
         - llvm-toolchain-precise-3.8
         packages:
         - clang-3.8
+  # fbx2019
+  - os: linux
+    compiler: gcc
+    env:
+      - fbx_download=https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_linux.tar.gz
+  - os: osx
+    compiler: clang
+    env:
+      - fbx_download=https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_clang_mac.pkg.tgz
 
 before_install:
 - echo before_install----------------------------------------------------------
@@ -159,19 +168,21 @@ install:
   fi
 # Download and install fbx sdk
 - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+    FBX_DOWNLOAD=${fbx_download:-"http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_linux.tar.gz"}
     mkdir fbx;
     cd fbx;
-    sudo wget http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_linux.tar.gz;
-    sudo tar -xf "fbx20171_fbxsdk_linux.tar.gz";
-    yes yes | sudo ./fbx20171_fbxsdk_linux /usr/local;
+    sudo wget $FBX_DOWNLOAD -O fbx.tar.gz;
+    sudo tar -xf "fbx.tar.gz";
+    yes yes | sudo ./*_fbxsdk_linux /usr/local;
     cd ..;
   fi
 - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    FBX_DOWNLOAD=${fbx_download:-"http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_clang_mac.pkg.tgz"}
     mkdir fbx;
     cd fbx;
-    sudo wget http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_clang_mac.pkg.tgz;
-    sudo tar -xf "fbx20171_fbxsdk_clang_mac.pkg.tgz";
-    sudo installer -pkg fbx20171_fbxsdk_clang_macos.pkg -target /;
+    sudo wget $FBX_DOWNLOAD -O fbx.tgz;
+    sudo tar -xf "fbx.tgz";
+    sudo installer -pkg *_fbxsdk_clang_macos.pkg -target /;
     cd ..;
   fi
 # Download and install emscripten sdk  

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,12 +149,22 @@ matrix:
         - clang-3.8
   # fbx2019
   - os: linux
-    compiler: gcc
+    compiler: gcc-6
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-6
     env:
+      - env_build_cpp11=1
+      - env_cmake_cxx_compiler=g++-6
+      - env_cmake_c_compiler=gcc-6
       - fbx_download=https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_linux.tar.gz
   - os: osx
     compiler: clang
     env:
+      - env_build_cpp11=1
       - fbx_download=https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_clang_mac.pkg.tgz
 
 before_install:
@@ -167,13 +177,17 @@ install:
     sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev;
   fi
 # Download and install fbx sdk
+# "|| true" because 2019 sdk would return code 130 when reading the readme (lol)
+# chmod because fbx2019 will install with 700
 - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
-    FBX_DOWNLOAD=${fbx_download:-"http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_linux.tar.gz"}
+    FBX_DOWNLOAD=${fbx_download:-"http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_linux.tar.gz"};
     mkdir fbx;
     cd fbx;
     sudo wget $FBX_DOWNLOAD -O fbx.tar.gz;
     sudo tar -xf "fbx.tar.gz";
-    yes yes | sudo ./*_fbxsdk_linux /usr/local;
+    (yes yes | sudo ./*_fbxsdk_linux /usr/local) || true;
+    sudo chmod -R 755 /usr/local/lib
+    sudo chmod -R 755 /usr/local/include
     cd ..;
   fi
 - if [[ $TRAVIS_OS_NAME == "osx" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,17 @@ environment:
     env_cmake_configuration: Release
     env_fbxsdk_path: "http://download.autodesk.com/us/fbx/2017/2017.1/fbx20171_fbxsdk_vs2015_win.exe"
     env_build_msvc_rt_dll: "0"
+  - env_cmake_generator: "Visual Studio 15 2017 Win64"
+    env_cmake_configuration: Debug
+    env_fbxsdk_path: "https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe"
+  - env_cmake_generator: "Visual Studio 15 2017 Win64"
+    env_cmake_configuration: Release
+    env_fbxsdk_path: "https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe"
+    env_build_msvc_rt_dll: "1"
+  - env_cmake_generator: "Visual Studio 15 2017 Win64"
+    env_cmake_configuration: Release
+    env_fbxsdk_path: "https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_vs2017_win.exe"
+    env_build_msvc_rt_dll: "0"
 
   # No fbx sdk
   - env_cmake_generator: "Visual Studio 15 2017"


### PR DESCRIPTION
1. Apparently vs2017 didn't increase the major version of cl.exe.
2. at least on windows after generating and trying to build I am getting
dozens of linker errors. the sdk contains bundled versions for xml and
zlib. I have modified the cmake file to include them as well for msvc.
3. the LIBS_DEBUG stuff was unused and I removed it