### PR TITLE
Hotfix/operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+  - [base] #83 Allows user code to disable definition of global namespace sse \_m128 +-/* operators, as they might conflict with other sse math libraries.
+
 Release version 0.11.0
 ----------------------
 * Library

--- a/include/ozz/base/maths/internal/simd_math_sse-inl.h
+++ b/include/ozz/base/maths/internal/simd_math_sse-inl.h
@@ -2008,6 +2008,7 @@ OZZ_INLINE ozz::math::Float4x4 operator-(const ozz::math::Float4x4& _a,
 }  // namespace ozz
 
 #if !defined(__GNUC__)
+#if !defined(OZZ_DISABLE_SSE_NATIVE_OPERATORS)
 OZZ_INLINE ozz::math::SimdFloat4 operator+(ozz::math::_SimdFloat4 _a,
                                            ozz::math::_SimdFloat4 _b) {
   return _mm_add_ps(_a, _b);
@@ -2031,6 +2032,7 @@ OZZ_INLINE ozz::math::SimdFloat4 operator/(ozz::math::_SimdFloat4 _a,
                                            ozz::math::_SimdFloat4 _b) {
   return _mm_div_ps(_a, _b);
 }
+#endif  // !defined(OZZ_DISABLE_SSE_NATIVE_OPERATORS)
 #endif  // !defined(__GNUC__)
 
 namespace ozz {

--- a/include/ozz/base/maths/simd_math.h
+++ b/include/ozz/base/maths/simd_math.h
@@ -1183,6 +1183,7 @@ OZZ_INLINE ozz::math::Float4x4 operator-(const ozz::math::Float4x4& _a,
 }  // namespace ozz
 
 #if !defined(__GNUC__) || defined(OZZ_SIMD_REF)
+#if !defined(OZZ_DISABLE_SSE_NATIVE_OPERATORS)
 // Returns per element addition of _a and _b.
 OZZ_INLINE ozz::math::SimdFloat4 operator+(ozz::math::_SimdFloat4 _a,
                                            ozz::math::_SimdFloat4 _b);
@@ -1201,6 +1202,7 @@ OZZ_INLINE ozz::math::SimdFloat4 operator*(ozz::math::_SimdFloat4 _a,
 // Returns per element division of _a and _b.
 OZZ_INLINE ozz::math::SimdFloat4 operator/(ozz::math::_SimdFloat4 _a,
                                            ozz::math::_SimdFloat4 _b);
+#endif  // !defined(OZZ_DISABLE_SSE_NATIVE_OPERATORS)
 #endif  // !defined(__GNUC__) || defined(OZZ_SIMD_REF)
 
 // Implement format conversions.


### PR DESCRIPTION
Allows user code to disable definition of global namespace sse \_m128 +-/* operators, as they might conflict with other sse math libraries.