### PR TITLE
Fixes possible nullptr in call to memcpy

### DIFF
--- a/src/base/io/stream.cc
+++ b/src/base/io/stream.cc
@@ -206,7 +206,9 @@ bool MemoryStream::Resize(size_t _size) {
     const size_t new_size = ozz::Align(_size, kBufferSizeIncrement);
     char* new_buffer = reinterpret_cast<char*>(
         ozz::memory::default_allocator()->Allocate(new_size, 16));
-    std::memcpy(new_buffer, buffer_, alloc_size_);
+    if (buffer_ != nullptr) {
+      std::memcpy(new_buffer, buffer_, alloc_size_);
+    }
     ozz::memory::default_allocator()->Deallocate(buffer_);
     buffer_ = new_buffer;
     alloc_size_ = new_size;


### PR DESCRIPTION
When resizing an empty stream, the old code would call memcpy an a
nullptr for 0 bytes.  This is undefined behavior and triggers the
undefined behavior sanitizer from clang.  The new code checks for a
nullptr before calling memcpy.

Resolves: #98