### PR TITLE
Adds DLL export functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(ozz_build_tests "Build unit tests" ON)
 option(ozz_build_simd_ref "Force SIMD math reference implementation" OFF)
 option(ozz_build_msvc_rt_dll "Select msvc DLL runtime library" ON)
 option(ozz_build_postfix "Use per config postfix name" ON)
+option(ozz_build_dll "Build ozz runtime libraries as DLLs" OFF)
 
 # Include ozz cmake parameters and scripts
 include(CheckCXXCompilerFlag)

--- a/include/ozz/animation/offline/additive_animation_builder.h
+++ b/include/ozz/animation/offline/additive_animation_builder.h
@@ -46,7 +46,7 @@ struct RawAnimation;
 // Defines the class responsible for building a delta animation from an offline
 // raw animation. This is used to create animations compatible with additive
 // blending.
-class AdditiveAnimationBuilder {
+class OZZ_ANIMOFFLINE_DLL AdditiveAnimationBuilder {
  public:
   // Initializes the builder.
   AdditiveAnimationBuilder();

--- a/include/ozz/animation/offline/animation_builder.h
+++ b/include/ozz/animation/offline/animation_builder.h
@@ -44,7 +44,7 @@ struct RawAnimation;
 // Defines the class responsible of building runtime animation instances from
 // offline raw animations.
 // No optimization at all is performed on the raw animation.
-class AnimationBuilder {
+class OZZ_ANIMOFFLINE_DLL AnimationBuilder {
  public:
   // Creates an Animation based on _raw_animation and *this builder parameters.
   // Returns a valid Animation on success.

--- a/include/ozz/animation/offline/animation_optimizer.h
+++ b/include/ozz/animation/offline/animation_optimizer.h
@@ -54,7 +54,7 @@ struct RawAnimation;
 // that leads to the hand if user wants it to be precise. Default optimization
 // tolerances are set in order to favor quality over runtime performances and
 // memory footprint.
-class AnimationOptimizer {
+class OZZ_ANIMOFFLINE_DLL AnimationOptimizer {
  public:
   // Initializes the optimizer with default tolerances (favoring quality).
   AnimationOptimizer();

--- a/include/ozz/animation/offline/fbx/fbx.h
+++ b/include/ozz/animation/offline/fbx/fbx.h
@@ -33,6 +33,19 @@
 #include "ozz/base/maths/simd_math.h"
 #include "ozz/base/maths/transform.h"
 
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_ANIMATIONFBX_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_ANIMFBX_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_ANIMFBX_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_ANIMFBX_DLL
+#endif
+
 namespace ozz {
 namespace math {
 struct Transform;
@@ -42,7 +55,7 @@ namespace offline {
 namespace fbx {
 
 // Manages FbxManager instance.
-class FbxManagerInstance {
+class OZZ_ANIMFBX_DLL FbxManagerInstance {
  public:
   // Instantiates FbxManager.
   FbxManagerInstance();
@@ -58,7 +71,7 @@ class FbxManagerInstance {
 };
 
 // Default io settings used to import a scene.
-class FbxDefaultIOSettings {
+class OZZ_ANIMFBX_DLL FbxDefaultIOSettings {
  public:
   // Instantiates default settings.
   explicit FbxDefaultIOSettings(const FbxManagerInstance& _manager);
@@ -77,13 +90,13 @@ class FbxDefaultIOSettings {
 };
 
 // Io settings used to import an animation from a scene.
-class FbxAnimationIOSettings : public FbxDefaultIOSettings {
+class OZZ_ANIMFBX_DLL FbxAnimationIOSettings : public FbxDefaultIOSettings {
  public:
   FbxAnimationIOSettings(const FbxManagerInstance& _manager);
 };
 
 // Io settings used to import a skeleton from a scene.
-class FbxSkeletonIOSettings : public FbxDefaultIOSettings {
+class OZZ_ANIMFBX_DLL FbxSkeletonIOSettings : public FbxDefaultIOSettings {
  public:
   FbxSkeletonIOSettings(const FbxManagerInstance& _manager);
 };
@@ -94,7 +107,7 @@ class FbxSkeletonIOSettings : public FbxDefaultIOSettings {
 // While Fbx sdk FbxAxisSystem::ConvertScene and FbxSystem::ConvertScene only
 // affect scene root, this class functions can be used to bake nodes, vertices,
 // animations transformations...
-class FbxSystemConverter {
+class OZZ_ANIMFBX_DLL FbxSystemConverter {
  public:
   // Initialize converter with fbx scene systems.
   FbxSystemConverter(const FbxAxisSystem& _from_axis,
@@ -133,7 +146,7 @@ class FbxSystemConverter {
 };
 
 // Loads a scene from a Fbx file.
-class FbxSceneLoader {
+class OZZ_ANIMFBX_DLL FbxSceneLoader {
  public:
   // Loads the scene that can then be obtained with scene() function.
   FbxSceneLoader(const char* _filename, const char* _password,

--- a/include/ozz/animation/offline/fbx/fbx_animation.h
+++ b/include/ozz/animation/offline/fbx/fbx_animation.h
@@ -51,34 +51,40 @@ struct RawquaternionTrack;
 
 namespace fbx {
 
-OzzImporter::AnimationNames GetAnimationNames(FbxSceneLoader& _scene_loader);
+OZZ_ANIMFBX_DLL OzzImporter::AnimationNames GetAnimationNames(
+    FbxSceneLoader& _scene_loader);
 
-bool ExtractAnimation(const char* _animation_name,
+OZZ_ANIMFBX_DLL bool ExtractAnimation(const char* _animation_name,
                       FbxSceneLoader& _scene_loader, const Skeleton& _skeleton,
                       float _sampling_rate, RawAnimation* _animation);
 
-OzzImporter::NodeProperties GetNodeProperties(FbxSceneLoader& _scene_loader,
+OZZ_ANIMFBX_DLL OzzImporter::NodeProperties GetNodeProperties(
+    FbxSceneLoader& _scene_loader,
                                               const char* _node_name);
 
-bool ExtractTrack(const char* _animation_name, const char* _node_name,
+OZZ_ANIMFBX_DLL bool ExtractTrack(const char* _animation_name,
+                                  const char* _node_name,
                   const char* _track_name,
                   OzzImporter::NodeProperty::Type _type,
                   FbxSceneLoader& _scene_loader, float _sampling_rate,
                   RawFloatTrack* _track);
 
-bool ExtractTrack(const char* _animation_name, const char* _node_name,
+OZZ_ANIMFBX_DLL bool ExtractTrack(const char* _animation_name,
+                                  const char* _node_name,
                   const char* _track_name,
                   OzzImporter::NodeProperty::Type _type,
                   FbxSceneLoader& _scene_loader, float _sampling_rate,
                   RawFloat2Track* _track);
 
-bool ExtractTrack(const char* _animation_name, const char* _node_name,
+OZZ_ANIMFBX_DLL bool ExtractTrack(const char* _animation_name,
+                                  const char* _node_name,
                   const char* _track_name,
                   OzzImporter::NodeProperty::Type _type,
                   FbxSceneLoader& _scene_loader, float _sampling_rate,
                   RawFloat3Track* _track);
 
-bool ExtractTrack(const char* _animation_name, const char* _node_name,
+OZZ_ANIMFBX_DLL bool ExtractTrack(const char* _animation_name,
+                                  const char* _node_name,
                   const char* _track_name,
                   OzzImporter::NodeProperty::Type _type,
                   FbxSceneLoader& _scene_loader, float _sampling_rate,

--- a/include/ozz/animation/offline/fbx/fbx_skeleton.h
+++ b/include/ozz/animation/offline/fbx/fbx_skeleton.h
@@ -39,7 +39,7 @@ struct RawSkeleton;
 
 namespace fbx {
 
-bool ExtractSkeleton(FbxSceneLoader& _loader,
+OZZ_ANIMFBX_DLL bool ExtractSkeleton(FbxSceneLoader& _loader,
                      const OzzImporter::NodeType& _types,
                      RawSkeleton* _skeleton);
 

--- a/include/ozz/animation/offline/raw_animation.h
+++ b/include/ozz/animation/offline/raw_animation.h
@@ -55,7 +55,7 @@ namespace offline {
 //  3. Keyframes' time are all within [0,animation duration] range.
 // Animations that would fail this validation will fail to be converted by the
 // AnimationBuilder.
-struct RawAnimation {
+struct OZZ_ANIMOFFLINE_DLL RawAnimation {
   // Constructs a valid RawAnimation with a 1s default duration.
   RawAnimation();
 
@@ -146,7 +146,7 @@ OZZ_IO_TYPE_TAG("ozz-raw_animation", animation::offline::RawAnimation)
 
 // Should not be called directly but through io::Archive << and >> operators.
 template <>
-struct Extern<animation::offline::RawAnimation> {
+struct OZZ_ANIMOFFLINE_DLL Extern<animation::offline::RawAnimation> {
   static void Save(OArchive& _archive,
                    const animation::offline::RawAnimation* _animations,
                    size_t _count);

--- a/include/ozz/animation/offline/raw_animation_utils.h
+++ b/include/ozz/animation/offline/raw_animation_utils.h
@@ -38,22 +38,25 @@ namespace animation {
 namespace offline {
 
 // Translation interpolation method.
-math::Float3 LerpTranslation(const math::Float3& _a, const math::Float3& _b,
+OZZ_ANIMOFFLINE_DLL math::Float3 LerpTranslation(const math::Float3& _a,
+                                                 const math::Float3& _b,
                              float _alpha);
 
 // Rotation interpolation method.
-math::Quaternion LerpRotation(const math::Quaternion& _a,
+OZZ_ANIMOFFLINE_DLL math::Quaternion LerpRotation(const math::Quaternion& _a,
                               const math::Quaternion& _b, float _alpha);
 
 // Scale interpolation method.
-math::Float3 LerpScale(const math::Float3& _a, const math::Float3& _b,
+OZZ_ANIMOFFLINE_DLL math::Float3 LerpScale(const math::Float3& _a,
+                                           const math::Float3& _b,
                        float _alpha);
 
 // Samples a RawAnimation track. This function shall be used for offline
 // purpose. Use ozz::animation::Animation and ozz::animation::SamplingJob for
 // runtime purpose.
 // Returns false if track is invalid.
-bool SampleTrack(const RawAnimation::JointTrack& _track, float _time,
+OZZ_ANIMOFFLINE_DLL bool SampleTrack(const RawAnimation::JointTrack& _track,
+                                     float _time,
                  ozz::math::Transform* _transform);
 
 // Samples a RawAnimation. This function shall be used for offline
@@ -61,7 +64,8 @@ bool SampleTrack(const RawAnimation::JointTrack& _track, float _time,
 // runtime purpose.
 // _animation must be valid.
 // Returns false output range is too small or animation is invalid.
-bool SampleAnimation(const RawAnimation& _animation, float _time,
+OZZ_ANIMOFFLINE_DLL bool SampleAnimation(
+    const RawAnimation& _animation, float _time,
                      const span<ozz::math::Transform>& _transforms);
 
 // Implement fixed rate keyframe time iteration. This utility purpose is to
@@ -69,7 +73,7 @@ bool SampleAnimation(const RawAnimation& _animation, float _time,
 // between consecutive time samples have a fixed period.
 // This sounds trivial, but floating point error could occur if keyframe time
 // was accumulated for a long duration.
-class FixedRateSamplingTime {
+class OZZ_ANIMOFFLINE_DLL FixedRateSamplingTime {
  public:
   FixedRateSamplingTime(float _duration, float _frequency);
 

--- a/include/ozz/animation/offline/raw_skeleton.h
+++ b/include/ozz/animation/offline/raw_skeleton.h
@@ -47,7 +47,7 @@ namespace offline {
 // The public API exposed through std:vector's of joints can be used freely with
 // the only restriction that the total number of joints does not exceed
 // Skeleton::kMaxJoints.
-struct RawSkeleton {
+struct OZZ_ANIMOFFLINE_DLL RawSkeleton {
   // Construct an empty skeleton.
   RawSkeleton();
 
@@ -139,7 +139,7 @@ OZZ_IO_TYPE_TAG("ozz-raw_skeleton", animation::offline::RawSkeleton)
 
 // Should not be called directly but through io::Archive << and >> operators.
 template <>
-struct Extern<animation::offline::RawSkeleton> {
+struct OZZ_ANIMOFFLINE_DLL Extern<animation::offline::RawSkeleton> {
   static void Save(OArchive& _archive,
                    const animation::offline::RawSkeleton* _skeletons,
                    size_t _count);

--- a/include/ozz/animation/offline/raw_track.h
+++ b/include/ozz/animation/offline/raw_track.h
@@ -109,11 +109,11 @@ struct RawTrack {
 }  // namespace internal
 
 // Offline user-channel animation track type instantiation.
-struct RawFloatTrack : public internal::RawTrack<float> {};
-struct RawFloat2Track : public internal::RawTrack<math::Float2> {};
-struct RawFloat3Track : public internal::RawTrack<math::Float3> {};
-struct RawFloat4Track : public internal::RawTrack<math::Float4> {};
-struct RawQuaternionTrack : public internal::RawTrack<math::Quaternion> {};
+struct OZZ_ANIMOFFLINE_DLL RawFloatTrack : public internal::RawTrack<float> {};
+struct OZZ_ANIMOFFLINE_DLL RawFloat2Track : public internal::RawTrack<math::Float2> {};
+struct OZZ_ANIMOFFLINE_DLL RawFloat3Track : public internal::RawTrack<math::Float3> {};
+struct OZZ_ANIMOFFLINE_DLL RawFloat4Track : public internal::RawTrack<math::Float4> {};
+struct OZZ_ANIMOFFLINE_DLL RawQuaternionTrack : public internal::RawTrack<math::Quaternion> {};
 }  // namespace offline
 }  // namespace animation
 

--- a/include/ozz/animation/offline/skeleton_builder.h
+++ b/include/ozz/animation/offline/skeleton_builder.h
@@ -43,7 +43,7 @@ namespace offline {
 struct RawSkeleton;
 
 // Defines the class responsible of building Skeleton instances.
-class SkeletonBuilder {
+class OZZ_ANIMOFFLINE_DLL SkeletonBuilder {
  public:
   // Creates a Skeleton based on _raw_skeleton and *this builder parameters.
   // Returns a Skeleton instance on success, an empty unique_ptr on failure. See

--- a/include/ozz/animation/offline/tools/import2ozz.h
+++ b/include/ozz/animation/offline/tools/import2ozz.h
@@ -35,6 +35,8 @@
 #include "ozz/animation/offline/raw_skeleton.h"
 #include "ozz/animation/offline/raw_track.h"
 
+#include "ozz/base/platform.h"
+
 namespace ozz {
 namespace animation {
 
@@ -51,7 +53,7 @@ namespace offline {
 // To import a new source data format, one will implement the pure virtual
 // functions of this interface. All the conversions end error processing are
 // done by the tool.
-class OzzImporter {
+class OZZ_ANIMTOOLS_DLL OzzImporter {
  public:
   virtual ~OzzImporter() {}
 

--- a/include/ozz/animation/offline/track_builder.h
+++ b/include/ozz/animation/offline/track_builder.h
@@ -53,7 +53,7 @@ struct RawQuaternionTrack;
 // offline tracks.The input raw track is first validated. Runtime conversion of
 // a validated raw track cannot fail. Note that no optimization is performed on
 // the data at all.
-class TrackBuilder {
+class OZZ_ANIMOFFLINE_DLL TrackBuilder {
  public:
   // Creates a Track based on _raw_track and *this builder parameters.
   // Returns a track instance on success, an empty unique_ptr on failure. See

--- a/include/ozz/animation/offline/track_optimizer.h
+++ b/include/ozz/animation/offline/track_optimizer.h
@@ -28,6 +28,8 @@
 #ifndef OZZ_OZZ_ANIMATION_OFFLINE_TRACK_OPTIMIZER_H_
 #define OZZ_OZZ_ANIMATION_OFFLINE_TRACK_OPTIMIZER_H_
 
+#include <ozz/base/platform.h>
+
 namespace ozz {
 namespace animation {
 namespace offline {
@@ -44,7 +46,7 @@ struct RawQuaternionTrack;
 // keyframes (within a tolerance value) are removed from the track. Default
 // optimization tolerances are set in order to favor quality over runtime
 // performances and memory footprint.
-class TrackOptimizer {
+class OZZ_ANIMOFFLINE_DLL TrackOptimizer {
  public:
   // Initializes the optimizer with default tolerances (favoring quality).
   TrackOptimizer();

--- a/include/ozz/animation/runtime/animation.h
+++ b/include/ozz/animation/runtime/animation.h
@@ -58,7 +58,7 @@ struct QuaternionKey;
 // joints order of the runtime skeleton structure. In order to optimize cache
 // coherency when sampling the animation, Keyframes in this array are sorted by
 // time, then by track number.
-class Animation {
+class OZZ_ANIMATION_DLL Animation {
  public:
   // Builds a default animation.
   Animation();

--- a/include/ozz/animation/runtime/animation_utils.h
+++ b/include/ozz/animation/runtime/animation_utils.h
@@ -35,9 +35,12 @@ namespace animation {
 
 // Count translation, rotation or scale keyframes for a given track number. Use
 // a negative _track value to count all tracks.
-int CountTranslationKeyframes(const Animation& _animation, int _track = -1);
-int CountRotationKeyframes(const Animation& _animation, int _track = -1);
-int CountScaleKeyframes(const Animation& _animation, int _track = -1);
+OZZ_ANIMATION_DLL int CountTranslationKeyframes(const Animation& _animation,
+                                                int _track = -1);
+OZZ_ANIMATION_DLL int CountRotationKeyframes(const Animation& _animation,
+                                             int _track = -1);
+OZZ_ANIMATION_DLL int CountScaleKeyframes(const Animation& _animation,
+                                          int _track = -1);
 }  // namespace animation
 }  // namespace ozz
 #endif  // OZZ_OZZ_ANIMATION_RUNTIME_ANIMATION_UTILS_H_

--- a/include/ozz/animation/runtime/blending_job.h
+++ b/include/ozz/animation/runtime/blending_job.h
@@ -52,7 +52,7 @@ namespace animation {
 // blend operations in a single pass.
 // The job does not owned any buffers (input/output) and will thus not delete
 // them during job's destruction.
-struct BlendingJob {
+struct OZZ_ANIMATION_DLL BlendingJob {
   // Default constructor, initializes default values.
   BlendingJob();
 
@@ -75,7 +75,7 @@ struct BlendingJob {
 
   // Defines a layer of blending input data (local space transforms) and
   // parameters (weights).
-  struct Layer {
+  struct OZZ_ANIMATION_DLL Layer {
     // Default constructor, initializes default values.
     Layer();
 

--- a/include/ozz/animation/runtime/ik_aim_job.h
+++ b/include/ozz/animation/runtime/ik_aim_job.h
@@ -50,7 +50,7 @@ namespace animation {
 // vector should aim the target.
 // Result is unstable if joint-to-target direction is parallel to pole vector,
 // or if target is too close to joint position.
-struct IKAimJob {
+struct OZZ_ANIMATION_DLL IKAimJob {
   // Default constructor, initializes default values.
   IKAimJob();
 

--- a/include/ozz/animation/runtime/ik_two_bone_job.h
+++ b/include/ozz/animation/runtime/ik_two_bone_job.h
@@ -51,7 +51,7 @@ namespace animation {
 // ancestors (joints in-between will simply remain fixed).
 // Implementation is inspired by Autodesk Maya 2 bone IK, improved stability
 // wise and extended with Soften IK.
-struct IKTwoBoneJob {
+struct OZZ_ANIMATION_DLL IKTwoBoneJob {
   // Constructor, initializes default values.
   IKTwoBoneJob();
 

--- a/include/ozz/animation/runtime/local_to_model_job.h
+++ b/include/ozz/animation/runtime/local_to_model_job.h
@@ -55,7 +55,7 @@ class Skeleton;
 // ordered like skeleton's joints. Output are matrices, because the combination
 // of affine transformations can contain shearing or complex transformation
 // that cannot be represented as Transform object.
-struct LocalToModelJob {
+struct OZZ_ANIMATION_DLL LocalToModelJob {
   // Default constructor, initializes default values.
   LocalToModelJob();
 

--- a/include/ozz/animation/runtime/sampling_job.h
+++ b/include/ozz/animation/runtime/sampling_job.h
@@ -55,7 +55,7 @@ class SamplingCache;
 // the animation forward. Backward sampling works, but isn't optimized through
 // the cache. The job does not owned the buffers (in/output) and will thus not
 // delete them during job's destruction.
-struct SamplingJob {
+struct OZZ_ANIMATION_DLL SamplingJob {
   // Default constructor, initializes default values.
   SamplingJob();
 
@@ -100,7 +100,7 @@ struct InterpSoaQuaternion;
 
 // Declares the cache object used by the workload to take advantage of the
 // frame coherency of animation sampling.
-class SamplingCache {
+class OZZ_ANIMATION_DLL SamplingCache {
  public:
   // Constructs an empty cache. The cache needs to be resized with the
   // appropriate number of tracks before it can be used with a SamplingJob.

--- a/include/ozz/animation/runtime/skeleton.h
+++ b/include/ozz/animation/runtime/skeleton.h
@@ -57,7 +57,7 @@ class SkeletonBuilder;
 // order. This is enough to traverse the whole joint hierarchy. See
 // IterateJointsDF() from skeleton_utils.h that implements a depth-first
 // traversal utility.
-class Skeleton {
+class OZZ_ANIMATION_DLL Skeleton {
  public:
   // Defines Skeleton constant values.
   enum Constants {

--- a/include/ozz/animation/runtime/skeleton_utils.h
+++ b/include/ozz/animation/runtime/skeleton_utils.h
@@ -37,8 +37,8 @@ namespace ozz {
 namespace animation {
 
 // Get bind-pose of a skeleton joint.
-ozz::math::Transform GetJointLocalBindPose(const Skeleton& _skeleton,
-                                           int _joint);
+OZZ_ANIMATION_DLL ozz::math::Transform GetJointLocalBindPose(
+    const Skeleton& _skeleton, int _joint);
 
 // Test if a joint is a leaf. _joint number must be in range [0, num joints].
 // "_joint" is a leaf if it's the last joint, or next joint's parent isn't
@@ -52,7 +52,7 @@ inline bool IsLeaf(const Skeleton& _skeleton, int _joint) {
 }
 
 // Finds joint index by name. Uses a case sensitive comparison.
-int FindJoint(const Skeleton& _skeleton, const char* _name);
+OZZ_ANIMATION_DLL int FindJoint(const Skeleton& _skeleton, const char* _name);
 
 // Applies a specified functor to each joint in a depth-first order.
 // _Fct is of type void(int _current, int _parent) where the first argument

--- a/include/ozz/animation/runtime/track.h
+++ b/include/ozz/animation/runtime/track.h
@@ -99,7 +99,7 @@ class Track {
   span<uint8_t> steps_;
 
   // Track name.
-  char* name_;
+  char* name_ = nullptr;
 };
 
 // Definition of operations policies per track value type.
@@ -146,11 +146,11 @@ inline math::Quaternion TrackPolicy<math::Quaternion>::identity() {
 }  // namespace internal
 
 // Runtime track data structure instantiation.
-class FloatTrack : public internal::Track<float> {};
-class Float2Track : public internal::Track<math::Float2> {};
-class Float3Track : public internal::Track<math::Float3> {};
-class Float4Track : public internal::Track<math::Float4> {};
-class QuaternionTrack : public internal::Track<math::Quaternion> {};
+class OZZ_ANIMATION_DLL FloatTrack : public internal::Track<float> {};
+class OZZ_ANIMATION_DLL Float2Track : public internal::Track<math::Float2> {};
+class OZZ_ANIMATION_DLL Float3Track : public internal::Track<math::Float3> {};
+class OZZ_ANIMATION_DLL Float4Track : public internal::Track<math::Float4> {};
+class OZZ_ANIMATION_DLL QuaternionTrack : public internal::Track<math::Quaternion> {};
 
 }  // namespace animation
 namespace io {

--- a/include/ozz/animation/runtime/track_sampling_job.h
+++ b/include/ozz/animation/runtime/track_sampling_job.h
@@ -65,14 +65,15 @@ struct TrackSamplingJob {
 // Track sampling job implementation. Track sampling allows to query a track
 // value for a specified ratio. This is a ratio rather than a time because
 // tracks have no duration.
-struct FloatTrackSamplingJob : public internal::TrackSamplingJob<FloatTrack> {};
-struct Float2TrackSamplingJob : public internal::TrackSamplingJob<Float2Track> {
-};
-struct Float3TrackSamplingJob : public internal::TrackSamplingJob<Float3Track> {
-};
-struct Float4TrackSamplingJob : public internal::TrackSamplingJob<Float4Track> {
-};
-struct QuaternionTrackSamplingJob
+struct OZZ_ANIMATION_DLL FloatTrackSamplingJob
+    : public internal::TrackSamplingJob<FloatTrack> {};
+struct OZZ_ANIMATION_DLL Float2TrackSamplingJob
+    : public internal::TrackSamplingJob<Float2Track> {};
+struct OZZ_ANIMATION_DLL Float3TrackSamplingJob
+    : public internal::TrackSamplingJob<Float3Track> {};
+struct OZZ_ANIMATION_DLL Float4TrackSamplingJob
+    : public internal::TrackSamplingJob<Float4Track> {};
+struct OZZ_ANIMATION_DLL QuaternionTrackSamplingJob
     : public internal::TrackSamplingJob<QuaternionTrack> {};
 
 }  // namespace animation

--- a/include/ozz/animation/runtime/track_triggering_job.h
+++ b/include/ozz/animation/runtime/track_triggering_job.h
@@ -46,7 +46,7 @@ class FloatTrack;
 // track types isn't possible.
 // The job execution actually performs a lazy evaluation of edges. It builds an
 // iterator that will process the next edge on each call to ++ operator.
-struct TrackTriggeringJob {
+struct OZZ_ANIMATION_DLL TrackTriggeringJob {
   TrackTriggeringJob();
 
   // Validates job parameters.
@@ -95,7 +95,7 @@ struct TrackTriggeringJob {
 // Iterator implementation. Calls to ++ operator will compute the next edge. It
 // should be compared (using operator !=) to job's end iterator to test if the
 // last edge has been reached.
-class TrackTriggeringJob::Iterator {
+class OZZ_ANIMATION_DLL TrackTriggeringJob::Iterator {
  public:
   Iterator() : job_(nullptr), outer_(0.f), inner_(0) {}
 

--- a/include/ozz/base/containers/string_archive.h
+++ b/include/ozz/base/containers/string_archive.h
@@ -38,7 +38,7 @@ namespace io {
 OZZ_IO_TYPE_NOT_VERSIONABLE(ozz::string)
 
 template <>
-struct Extern<ozz::string> {
+struct OZZ_BASE_DLL Extern<ozz::string> {
   static void Save(OArchive& _archive, const ozz::string* _values,
                    size_t _count);
   static void Load(IArchive& _archive, ozz::string* _values, size_t _count,

--- a/include/ozz/base/io/archive.h
+++ b/include/ozz/base/io/archive.h
@@ -102,7 +102,7 @@ struct Tagger;
 // The output endianness mode is set at construction time. It is written to the
 // stream to allow the IArchive to perform the required conversion to the native
 // endianness mode while reading.
-class OArchive {
+class OZZ_BASE_DLL OArchive {
  public:
   // Constructs an output archive from the Stream _stream that must be valid
   // and opened for writing.
@@ -171,7 +171,7 @@ class OArchive {
 // Implements input archive concept used to load/de-serialize data to a Stream.
 // Endianness conversions are automatically performed according to the Archive
 // and the native formats.
-class IArchive {
+class OZZ_BASE_DLL IArchive {
  public:
   // Constructs an input archive from the Stream _stream that must be opened for
   // reading, at the same tell (position in the stream) as when it was passed to

--- a/include/ozz/base/io/stream.h
+++ b/include/ozz/base/io/stream.h
@@ -40,7 +40,7 @@ namespace io {
 
 // Declares a stream access interface that conforms with CRT FILE API.
 // This interface should be used to remap io operations.
-class Stream {
+class OZZ_BASE_DLL Stream {
  public:
   // Tests whether a file is opened.
   virtual bool opened() const = 0;
@@ -86,7 +86,7 @@ class Stream {
 };
 
 // Implements Stream of type File.
-class File : public Stream {
+class OZZ_BASE_DLL File : public Stream {
  public:
   // Test if a file at path _filename exists.
   // Note that this function is costly. If you aim to open the file right after,
@@ -133,7 +133,7 @@ class File : public Stream {
 
 // Implements an in-memory Stream. Allows to use a memory buffer as a Stream.
 // The opening mode is equivalent to fopen w+b (binary read/write).
-class MemoryStream : public Stream {
+class OZZ_BASE_DLL MemoryStream : public Stream {
  public:
   // Construct an empty memory stream opened in w+b mode.
   MemoryStream();

--- a/include/ozz/base/log.h
+++ b/include/ozz/base/log.h
@@ -34,6 +34,8 @@
 // So it is included here to ensure a portable behavior.
 #include <cstring>
 
+#include "platform.h"
+
 // Proposes a logging interface that redirects logs to std::cout, clog and cerr
 // output streams. This interface adds a logging level functionality (kSilent,
 // kStandard, kVerbose) to the std API, which can be set using
@@ -50,17 +52,17 @@ enum Level {
 };
 
 // Sets the global logging level.
-Level SetLevel(Level _level);
+OZZ_BASE_DLL Level SetLevel(Level _level);
 
 // Gets the global logging level.
-Level GetLevel();
+OZZ_BASE_DLL Level GetLevel();
 
 // Implements logging base class.
 // This class is not intended to be used publicly, it is derived by user
 // classes LogV, Log, Out, Err...
 // Forwards ostream::operator << to a standard ostream or a silent
 // ostringstream according to the logging level at construction time.
-class Logger {
+class OZZ_BASE_DLL Logger {
  public:
   // Forwards ostream::operator << for any type.
   template <typename _T>
@@ -101,28 +103,28 @@ class Logger {
 
 // Logs verbose output to the standard error stream (std::clog).
 // Enabled if logging level is Verbose.
-class LogV : public Logger {
+class OZZ_BASE_DLL LogV : public Logger {
  public:
   LogV();
 };
 
 // Logs output to the standard error stream (std::clog).
 // Enabled if logging level is not Silent.
-class Log : public Logger {
+class OZZ_BASE_DLL Log : public Logger {
  public:
   Log();
 };
 
 // Logs output to the standard output (std::cout).
 // Enabled if logging level is not Silent.
-class Out : public Logger {
+class OZZ_BASE_DLL Out : public Logger {
  public:
   Out();
 };
 
 // Logs error to the standard error stream (std::cerr).
 // Enabled if logging level is not Silent.
-class Err : public Logger {
+class OZZ_BASE_DLL Err : public Logger {
  public:
   Err();
 };
@@ -131,7 +133,7 @@ class Err : public Logger {
 // settings when exiting scope.
 // User is reponsible for making sure stream still exist upon RAII destruction.
 // See std::setprecision() for more details.
-class FloatPrecision {
+class OZZ_BASE_DLL FloatPrecision {
  public:
   FloatPrecision(const Logger& _logger, int _precision);
   ~FloatPrecision();

--- a/include/ozz/base/maths/box.h
+++ b/include/ozz/base/maths/box.h
@@ -39,7 +39,7 @@ namespace math {
 struct Float4x4;
 
 // Defines an axis aligned box.
-struct Box {
+struct OZZ_BASE_DLL Box {
   // Constructs an invalid box.
   Box();
 
@@ -78,7 +78,7 @@ OZZ_INLINE Box Merge(const Box& _a, const Box& _b) {
 }
 
 // Compute box transformation by a matrix.
-Box TransformBox(const Float4x4& _matrix, const Box& _box);
+OZZ_BASE_DLL Box TransformBox(const Float4x4& _matrix, const Box& _box);
 }  // namespace math
 }  // namespace ozz
 #endif  // OZZ_OZZ_BASE_MATHS_BOX_H_

--- a/include/ozz/base/maths/math_archive.h
+++ b/include/ozz/base/maths/math_archive.h
@@ -45,7 +45,7 @@ struct RectInt;
 namespace io {
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Float2)
 template <>
-struct Extern<math::Float2> {
+struct OZZ_BASE_DLL Extern<math::Float2> {
   static void Save(OArchive& _archive, const math::Float2* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Float2* _values, size_t _count,
@@ -54,7 +54,7 @@ struct Extern<math::Float2> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Float3)
 template <>
-struct Extern<math::Float3> {
+struct OZZ_BASE_DLL Extern<math::Float3> {
   static void Save(OArchive& _archive, const math::Float3* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Float3* _values, size_t _count,
@@ -63,7 +63,7 @@ struct Extern<math::Float3> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Float4)
 template <>
-struct Extern<math::Float4> {
+struct OZZ_BASE_DLL Extern<math::Float4> {
   static void Save(OArchive& _archive, const math::Float4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Float4* _values, size_t _count,
@@ -72,7 +72,7 @@ struct Extern<math::Float4> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Quaternion)
 template <>
-struct Extern<math::Quaternion> {
+struct OZZ_BASE_DLL Extern<math::Quaternion> {
   static void Save(OArchive& _archive, const math::Quaternion* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Quaternion* _values, size_t _count,
@@ -81,7 +81,7 @@ struct Extern<math::Quaternion> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Transform)
 template <>
-struct Extern<math::Transform> {
+struct OZZ_BASE_DLL Extern<math::Transform> {
   static void Save(OArchive& _archive, const math::Transform* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Transform* _values, size_t _count,
@@ -90,7 +90,7 @@ struct Extern<math::Transform> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Box)
 template <>
-struct Extern<math::Box> {
+struct OZZ_BASE_DLL Extern<math::Box> {
   static void Save(OArchive& _archive, const math::Box* _values, size_t _count);
   static void Load(IArchive& _archive, math::Box* _values, size_t _count,
                    uint32_t _version);
@@ -98,7 +98,7 @@ struct Extern<math::Box> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::RectFloat)
 template <>
-struct Extern<math::RectFloat> {
+struct OZZ_BASE_DLL Extern<math::RectFloat> {
   static void Save(OArchive& _archive, const math::RectFloat* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::RectFloat* _values, size_t _count,
@@ -107,7 +107,7 @@ struct Extern<math::RectFloat> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::RectInt)
 template <>
-struct Extern<math::RectInt> {
+struct OZZ_BASE_DLL Extern<math::RectInt> {
   static void Save(OArchive& _archive, const math::RectInt* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::RectInt* _values, size_t _count,

--- a/include/ozz/base/maths/quaternion.h
+++ b/include/ozz/base/maths/quaternion.h
@@ -38,7 +38,7 @@
 namespace ozz {
 namespace math {
 
-struct Quaternion {
+struct OZZ_BASE_DLL Quaternion {
   float x, y, z, w;
 
   // Constructs an uninitialized quaternion.

--- a/include/ozz/base/maths/rect.h
+++ b/include/ozz/base/maths/rect.h
@@ -28,12 +28,14 @@
 #ifndef OZZ_OZZ_BASE_MATHS_RECT_H_
 #define OZZ_OZZ_BASE_MATHS_RECT_H_
 
+#include "../platform.h"
+
 namespace ozz {
 namespace math {
 
 // Defines a rectangle by the integer coordinates of its lower-left and
 // width-height.
-struct RectInt {
+struct OZZ_BASE_DLL RectInt {
   // Constructs a uninitialized rectangle.
   RectInt() {}
 
@@ -65,7 +67,7 @@ struct RectInt {
 
 // Defines a rectangle by the floating point coordinates of its lower-left
 // and width-height.
-struct RectFloat {
+struct OZZ_BASE_DLL RectFloat {
   // Constructs a uninitialized rectangle.
   RectFloat() {}
 

--- a/include/ozz/base/maths/simd_math.h
+++ b/include/ozz/base/maths/simd_math.h
@@ -35,7 +35,7 @@ namespace ozz {
 namespace math {
 
 // Returns SIMDimplementation name has decided at library build time.
-const char* SimdImplementationName();
+OZZ_BASE_DLL const char* SimdImplementationName();
 
 namespace simd_float4 {
 // Returns a SimdFloat4 vector with all components set to 0.

--- a/include/ozz/base/maths/simd_math_archive.h
+++ b/include/ozz/base/maths/simd_math_archive.h
@@ -36,7 +36,7 @@ namespace ozz {
 namespace io {
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SimdFloat4)
 template <>
-struct Extern<math::SimdFloat4> {
+struct OZZ_BASE_DLL Extern<math::SimdFloat4> {
   static void Save(OArchive& _archive, const math::SimdFloat4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SimdFloat4* _values, size_t _count,
@@ -45,7 +45,7 @@ struct Extern<math::SimdFloat4> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SimdInt4)
 template <>
-struct Extern<math::SimdInt4> {
+struct OZZ_BASE_DLL Extern<math::SimdInt4> {
   static void Save(OArchive& _archive, const math::SimdInt4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SimdInt4* _values, size_t _count,
@@ -54,7 +54,7 @@ struct Extern<math::SimdInt4> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::Float4x4)
 template <>
-struct Extern<math::Float4x4> {
+struct OZZ_BASE_DLL Extern<math::Float4x4> {
   static void Save(OArchive& _archive, const math::Float4x4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::Float4x4* _values, size_t _count,

--- a/include/ozz/base/maths/soa_math_archive.h
+++ b/include/ozz/base/maths/soa_math_archive.h
@@ -43,7 +43,7 @@ struct SoaTransform;
 namespace io {
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaFloat2)
 template <>
-struct Extern<math::SoaFloat2> {
+struct OZZ_BASE_DLL Extern<math::SoaFloat2> {
   static void Save(OArchive& _archive, const math::SoaFloat2* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaFloat2* _values, size_t _count,
@@ -52,7 +52,7 @@ struct Extern<math::SoaFloat2> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaFloat3)
 template <>
-struct Extern<math::SoaFloat3> {
+struct OZZ_BASE_DLL Extern<math::SoaFloat3> {
   static void Save(OArchive& _archive, const math::SoaFloat3* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaFloat3* _values, size_t _count,
@@ -61,7 +61,7 @@ struct Extern<math::SoaFloat3> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaFloat4)
 template <>
-struct Extern<math::SoaFloat4> {
+struct OZZ_BASE_DLL Extern<math::SoaFloat4> {
   static void Save(OArchive& _archive, const math::SoaFloat4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaFloat4* _values, size_t _count,
@@ -70,7 +70,7 @@ struct Extern<math::SoaFloat4> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaQuaternion)
 template <>
-struct Extern<math::SoaQuaternion> {
+struct OZZ_BASE_DLL Extern<math::SoaQuaternion> {
   static void Save(OArchive& _archive, const math::SoaQuaternion* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaQuaternion* _values,
@@ -79,7 +79,7 @@ struct Extern<math::SoaQuaternion> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaFloat4x4)
 template <>
-struct Extern<math::SoaFloat4x4> {
+struct OZZ_BASE_DLL Extern<math::SoaFloat4x4> {
   static void Save(OArchive& _archive, const math::SoaFloat4x4* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaFloat4x4* _values,
@@ -88,7 +88,7 @@ struct Extern<math::SoaFloat4x4> {
 
 OZZ_IO_TYPE_NOT_VERSIONABLE(math::SoaTransform)
 template <>
-struct Extern<math::SoaTransform> {
+struct OZZ_BASE_DLL Extern<math::SoaTransform> {
   static void Save(OArchive& _archive, const math::SoaTransform* _values,
                    size_t _count);
   static void Load(IArchive& _archive, math::SoaTransform* _values,

--- a/include/ozz/base/maths/transform.h
+++ b/include/ozz/base/maths/transform.h
@@ -37,7 +37,7 @@ namespace math {
 
 // Stores an affine transformation with separate translation, rotation and scale
 // attributes.
-struct Transform {
+struct OZZ_BASE_DLL Transform {
   // Translation affine transformation component.
   Float3 translation;
 

--- a/include/ozz/base/maths/vec_float.h
+++ b/include/ozz/base/maths/vec_float.h
@@ -38,7 +38,7 @@ namespace ozz {
 namespace math {
 
 // Declares a 2d float vector.
-struct Float2 {
+struct OZZ_BASE_DLL Float2 {
   float x, y;
 
   // Constructs an uninitialized vector.
@@ -64,7 +64,7 @@ struct Float2 {
 };
 
 // Declares a 3d float vector.
-struct Float3 {
+struct OZZ_BASE_DLL Float3 {
   float x, y, z;
 
   // Constructs an uninitialized vector.
@@ -96,7 +96,7 @@ struct Float3 {
 };
 
 // Declares a 4d float vector.
-struct Float4 {
+struct OZZ_BASE_DLL Float4 {
   float x, y, z, w;
 
   // Constructs an uninitialized vector.

--- a/include/ozz/base/memory/allocator.h
+++ b/include/ozz/base/memory/allocator.h
@@ -41,18 +41,18 @@ namespace memory {
 class Allocator;
 
 // Defines the default allocator accessor.
-Allocator* default_allocator();
+OZZ_BASE_DLL Allocator* default_allocator();
 
 // Set the default allocator, used for all dynamic allocation inside ozz.
 // Returns current memory allocator, such that in can be restored if needed.
-Allocator* SetDefaulAllocator(Allocator* _allocator);
+OZZ_BASE_DLL Allocator* SetDefaulAllocator(Allocator* _allocator);
 
 // Defines an abstract allocator class.
 // Implements helper methods to allocate/deallocate POD typed objects instead of
 // raw memory.
 // Implements New and Delete function to allocate C++ objects, as a replacement
 // of new and delete operators.
-class Allocator {
+class OZZ_BASE_DLL Allocator {
  public:
   // Default virtual destructor.
   virtual ~Allocator() {}

--- a/include/ozz/base/platform.h
+++ b/include/ozz/base/platform.h
@@ -41,6 +41,58 @@
 #include <cassert>
 #include <cstddef>
 
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_BASE_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_BASE_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_BASE_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_BASE_DLL
+#endif
+
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_ANIMATION_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_ANIMATION_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_ANIMATION_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_ANIMATION_DLL
+#endif
+
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_ANIMOFFLINE_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_ANIMOFFLINE_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_ANIMOFFLINE_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_ANIMOFFLINE_DLL
+#endif
+
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_ANIMATIONTOOLS_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_ANIMTOOLS_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_ANIMTOOLS_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_ANIMTOOLS_DLL
+#endif
+
 namespace ozz {
 
 // Finds the number of elements of a statically allocated array.
@@ -80,7 +132,7 @@ namespace ozz {
 // Case sensitive wildcard string matching:
 // - a ? sign matches any character, except an empty string.
 // - a * sign matches any string, including an empty string.
-bool strmatch(const char* _str, const char* _pattern);
+OZZ_BASE_DLL bool strmatch(const char* _str, const char* _pattern);
 
 // Tests whether _block is aligned to _alignment boundary.
 template <typename _Ty>

--- a/include/ozz/geometry/runtime/skinning_job.h
+++ b/include/ozz/geometry/runtime/skinning_job.h
@@ -31,6 +31,19 @@
 #include "ozz/base/platform.h"
 #include "ozz/base/span.h"
 
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_GEOMETRY_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_GEOMETRY_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_GEOMETRY_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_GEOMETRY_DLL
+#endif
+
 namespace ozz {
 namespace math {
 struct Float4x4;
@@ -73,7 +86,7 @@ namespace geometry {
 // should only be used when input matrices have non uniform scaling or shearing.
 // The job does not owned the buffers (in/output) and will thus not delete them
 // during job's destruction.
-struct SkinningJob {
+struct OZZ_GEOMETRY_DLL SkinningJob {
   // Default constructor, initializes default values.
   SkinningJob();
 

--- a/include/ozz/options/options.h
+++ b/include/ozz/options/options.h
@@ -83,6 +83,19 @@
 #include <cstddef>
 #include <string>
 
+#ifdef OZZ_USE_DYNAMIC_LINKING
+    #ifdef OZZ_BUILD_OPTIONS_LIB
+        // export for dynamic linking while building ozz
+        #define OZZ_OPTIONS_DLL __declspec(dllexport)
+    #else
+        // import for dynamic linking when just using ozz
+        #define OZZ_OPTIONS_DLL __declspec(dllimport)
+    #endif()
+#else
+    // static linking
+    #define OZZ_OPTIONS_DLL
+#endif
+
 namespace ozz {
 namespace options {
 
@@ -108,26 +121,26 @@ enum ParseResult {
 // _version and _usage are not copied, ParseCommandLine caller is in charge of
 // maintaining their allocation during application lifetime.
 // See ParseResult for more details about returned values.
-ParseResult ParseCommandLine(int _argc, const char* const* _argv,
+OZZ_OPTIONS_DLL ParseResult ParseCommandLine(int _argc, const char* const* _argv,
                              const char* _version, const char* _usage);
 
 // Get the executable path that was extracted from the last call to
 // ParseCommandLine.
 // If ParseCommandLine has never been called, then ParsedExecutablePath
 // returns a default empty string.
-std::string ParsedExecutablePath();
+OZZ_OPTIONS_DLL std::string ParsedExecutablePath();
 
 // Get the executable name that was extracted from the last call to
 // ParseCommandLine.
 // If ParseCommandLine has never been called, then ParsedExecutableName
 // returns a default empty string.
-const char* ParsedExecutableName();
+OZZ_OPTIONS_DLL const char* ParsedExecutableName();
 
 // Get the executable usage that was extracted from the last call to
 // ParseCommandLine.
 // If ParseCommandLine has never been called, then ParsedExecutableUsage
 // returns a default empty string.
-const char* ParsedExecutableUsage();
+OZZ_OPTIONS_DLL const char* ParsedExecutableUsage();
 
 #define OZZ_OPTIONS_DECLARE_BOOL(_name, _help, _default, _required)    \
   OZZ_OPTIONS_DECLARE_VARIABLE(ozz::options::BoolOption, _name, _help, \
@@ -168,7 +181,7 @@ const char* ParsedExecutableUsage();
       #_name, _help, _default, _required, _fn);
 
 // Defines option interface.
-class Option {
+class OZZ_OPTIONS_DLL Option {
  public:
   // Returns option's name.
   const char* name() const { return name_; }
@@ -298,7 +311,7 @@ typedef TypedOption<const char*> StringOption;
 // Declares the option parser class.
 // Option are registered by the parser and updated when command line arguments
 // are parsed.
-class Parser {
+class OZZ_OPTIONS_DLL Parser {
  public:
   // Construct a parser with only built-in options.
   Parser();

--- a/src/animation/offline/CMakeLists.txt
+++ b/src/animation/offline/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_animation_offline STATIC
+set(LIB_SOURCES
   decimate.h
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/raw_animation.h
   raw_animation.cc
@@ -22,6 +22,14 @@ add_library(ozz_animation_offline STATIC
   track_builder.cc
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/track_optimizer.h
   track_optimizer.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_animation_offline SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_animation_offline PRIVATE OZZ_BUILD_ANIMOFFLINE_LIB)
+else()
+  add_library(ozz_animation_offline STATIC ${LIB_SOURCES})
+endif()
+
 target_link_libraries(ozz_animation_offline
   ozz_animation)
 

--- a/src/animation/offline/fbx/CMakeLists.txt
+++ b/src/animation/offline/fbx/CMakeLists.txt
@@ -2,13 +2,22 @@ if(NOT ozz_build_fbx)
   return()
 endif()
 
-add_library(ozz_animation_fbx STATIC
+
+set(LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx.h
   fbx.cc
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx_animation.h
   fbx_animation.cc
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/fbx/fbx_skeleton.h
   fbx_skeleton.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_animation_fbx SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_animation_fbx PRIVATE OZZ_BUILD_ANIMATIONFBX_LIB)
+else()
+  add_library(ozz_animation_fbx STATIC ${LIB_SOURCES})
+endif()
+
 target_include_directories(ozz_animation_fbx
   PUBLIC $<BUILD_INTERFACE:${FBX_INCLUDE_DIRS}>)
 target_link_libraries(ozz_animation_fbx

--- a/src/animation/offline/tools/CMakeLists.txt
+++ b/src/animation/offline/tools/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/extern/jsoncpp json)
 
-add_library(ozz_animation_tools STATIC
+set(LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/offline/tools/import2ozz.h
   import2ozz.cc
   import2ozz_anim.h
@@ -15,10 +15,19 @@ add_library(ozz_animation_tools STATIC
   import2ozz_skel.cc
   import2ozz_track.h
   import2ozz_track.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_animation_tools SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_animation_tools PRIVATE OZZ_BUILD_ANIMATIONTOOLS_LIB)
+else()
+  add_library(ozz_animation_tools STATIC ${LIB_SOURCES})
+endif()
+
 target_link_libraries(ozz_animation_tools
   ozz_animation_offline
   ozz_options
   json)
+
 set_target_properties(ozz_animation_tools
   PROPERTIES FOLDER "ozz/tools")
 

--- a/src/animation/offline/tools/import2ozz_anim.h
+++ b/src/animation/offline/tools/import2ozz_anim.h
@@ -43,14 +43,15 @@ namespace animation {
 namespace offline {
 
 class OzzImporter;
-bool ImportAnimations(const Json::Value& _config, OzzImporter* _importer,
+OZZ_ANIMTOOLS_DLL bool ImportAnimations(const Json::Value& _config,
+                                        OzzImporter* _importer,
                       const ozz::Endianness _endianness);
 
 // Additive reference enum to config string conversions.
 struct AdditiveReferenceEnum {
   enum Value { kAnimation, kSkeleton };
 };
-struct AdditiveReference
+struct OZZ_ANIMTOOLS_DLL AdditiveReference
     : JsonEnum<AdditiveReference, AdditiveReferenceEnum::Value> {
   static EnumNames GetNames();
 };

--- a/src/animation/offline/tools/import2ozz_config.h
+++ b/src/animation/offline/tools/import2ozz_config.h
@@ -37,10 +37,10 @@ namespace animation {
 namespace offline {
 
 // Get the sanitized (all members are set, with the right types) configuration.
-bool ProcessConfiguration(Json::Value* _config);
+OZZ_ANIMTOOLS_DLL bool ProcessConfiguration(Json::Value* _config);
 
 // Internal function used to compare enum names.
-bool CompareName(const char* _a, const char* _b);
+OZZ_ANIMTOOLS_DLL bool CompareName(const char* _a, const char* _b);
 
 // Struct allowing inheriting class to provide enum names.
 template <typename _Type, typename _Enum>

--- a/src/animation/offline/tools/import2ozz_skel.h
+++ b/src/animation/offline/tools/import2ozz_skel.h
@@ -41,8 +41,9 @@ namespace offline {
 
 class OzzImporter;
 
-bool ImportSkeleton(const Json::Value& _config, OzzImporter* _importer,
-                    const ozz::Endianness _endianness);
+OZZ_ANIMTOOLS_DLL bool ImportSkeleton(const Json::Value& _config,
+                                      OzzImporter* _importer,
+                                      const ozz::Endianness _endianness);
 
 }  // namespace offline
 }  // namespace animation

--- a/src/animation/offline/tools/import2ozz_track.h
+++ b/src/animation/offline/tools/import2ozz_track.h
@@ -44,12 +44,14 @@ class Skeleton;
 namespace offline {
 
 class OzzImporter;
-bool ProcessTracks(OzzImporter& _importer, const char* _animation_name,
-                   const Skeleton& _skeleton, const Json::Value& _config,
-                   const ozz::Endianness _endianness);
+OZZ_ANIMTOOLS_DLL bool ProcessTracks(OzzImporter& _importer,
+                                     const char* _animation_name,
+                                     const Skeleton& _skeleton,
+                                     const Json::Value& _config,
+                                     const ozz::Endianness _endianness);
 
 // Property type enum to config string conversions.
-struct PropertyTypeConfig
+struct OZZ_ANIMTOOLS_DLL PropertyTypeConfig
     : JsonEnum<PropertyTypeConfig, OzzImporter::NodeProperty::Type> {
   static EnumNames GetNames();
 };

--- a/src/animation/runtime/CMakeLists.txt
+++ b/src/animation/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_animation STATIC
+set (LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/animation.h
   animation.cc
   animation_keyframe.h
@@ -25,7 +25,18 @@ add_library(ozz_animation STATIC
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/track_triggering_job.h
   ${PROJECT_SOURCE_DIR}/include/ozz/animation/runtime/track_triggering_job_trait.h
   track_triggering_job.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_animation SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_animation PRIVATE OZZ_BUILD_ANIMATION_LIB)
+  target_compile_options(ozz_animation PUBLIC /wd4251)
+  target_compile_options(ozz_animation PUBLIC /wd4661)
+else()
+  add_library(ozz_animation STATIC ${LIB_SOURCES})
+endif()
+
 target_link_libraries(ozz_animation
+  PUBLIC
   ozz_base)
 
 set_target_properties(ozz_animation

--- a/src/animation/runtime/animation_keyframe.h
+++ b/src/animation/runtime/animation_keyframe.h
@@ -46,7 +46,7 @@ namespace animation {
 // Defines the float3 key frame type, used for translations and scales.
 // Translation values are stored as half precision floats with 16 bits per
 // component.
-struct Float3Key {
+struct OZZ_ANIMATION_DLL Float3Key {
   float ratio;
   uint16_t track;
   uint16_t value[3];
@@ -67,7 +67,7 @@ struct Float3Key {
 // Quantization could be reduced to 11-11-10 bits as often used for animation
 // key frames, but in this case RotationKey structure would induce 16 bits of
 // padding.
-struct QuaternionKey {
+struct OZZ_ANIMATION_DLL QuaternionKey {
   float ratio;
   uint16_t track : 13;   // The track this key frame belongs to.
   uint16_t largest : 2;  // The largest component of the quaternion.

--- a/src/animation/runtime/track.cc
+++ b/src/animation/runtime/track.cc
@@ -142,11 +142,11 @@ void Track<_ValueType>::Load(ozz::io::IArchive& _archive, uint32_t _version) {
 }
 
 // Explicitly instantiate supported tracks.
-template class Track<float>;
-template class Track<math::Float2>;
-template class Track<math::Float3>;
-template class Track<math::Float4>;
-template class Track<math::Quaternion>;
+template class OZZ_ANIMATION_DLL Track<float>;
+template class OZZ_ANIMATION_DLL Track<math::Float2>;
+template class OZZ_ANIMATION_DLL Track<math::Float3>;
+template class OZZ_ANIMATION_DLL Track<math::Float4>;
+template class OZZ_ANIMATION_DLL Track<math::Quaternion>;
 
 }  // namespace internal
 }  // namespace animation

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ozz_base STATIC
+set (LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/include/ozz/base/endianness.h
   ${PROJECT_SOURCE_DIR}/include/ozz/base/gtest_helper.h
   ${PROJECT_SOURCE_DIR}/include/ozz/base/memory/allocator.h
@@ -54,11 +54,22 @@ add_library(ozz_base STATIC
   maths/soa_math_archive.cc
   ${PROJECT_SOURCE_DIR}/include/ozz/base/maths/simd_math_archive.h
   maths/simd_math_archive.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_base SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_base PUBLIC OZZ_USE_DYNAMIC_LINKING)
+  target_compile_definitions(ozz_base PRIVATE OZZ_BUILD_BASE_LIB)
+else()
+  add_library(ozz_base STATIC ${LIB_SOURCES})
+endif()
+
 target_include_directories(ozz_base PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+
 set_target_properties(ozz_base PROPERTIES FOLDER "ozz")
 
 install(TARGETS ozz_base DESTINATION lib)
 
 fuse_target("ozz_base")
+

--- a/src/geometry/runtime/CMakeLists.txt
+++ b/src/geometry/runtime/CMakeLists.txt
@@ -1,6 +1,16 @@
-add_library(ozz_geometry STATIC
+set(LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/include/ozz/geometry/runtime/skinning_job.h
   skinning_job.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_geometry SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_geometry PUBLIC OZZ_USE_DYNAMIC_LINKING)
+  target_compile_definitions(ozz_geometry PRIVATE OZZ_BUILD_GEOMETRY_LIB)
+  target_compile_options(ozz_geometry PUBLIC /wd4251)
+else()
+  add_library(ozz_geometry STATIC ${LIB_SOURCES})
+endif()
+
 target_link_libraries(ozz_geometry
   ozz_base)
 set_target_properties(ozz_geometry

--- a/src/options/CMakeLists.txt
+++ b/src/options/CMakeLists.txt
@@ -1,6 +1,16 @@
-add_library(ozz_options STATIC
+set(LIB_SOURCES
   ../../include/ozz/options/options.h
   options.cc)
+
+if(ozz_build_dll)
+  add_library(ozz_options SHARED ${LIB_SOURCES})
+  target_compile_definitions(ozz_options PUBLIC OZZ_USE_DYNAMIC_LINKING)
+  target_compile_definitions(ozz_options PRIVATE OZZ_BUILD_OPTIONS_LIB)
+  target_compile_options(ozz_options PUBLIC /wd4251)
+else()
+  add_library(ozz_options STATIC ${LIB_SOURCES})
+endif()
+
 target_include_directories(ozz_options PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)

--- a/src/options/options.cc
+++ b/src/options/options.cc
@@ -107,10 +107,10 @@ Registrer<_Option>::~Registrer() {
 }
 
 // Explicit instantiation of all supported types of Registrer.
-template class Registrer<TypedOption<bool>>;
-template class Registrer<TypedOption<int>>;
-template class Registrer<TypedOption<float>>;
-template class Registrer<TypedOption<const char*>>;
+template class OZZ_OPTIONS_DLL Registrer<TypedOption<bool>>;
+template class OZZ_OPTIONS_DLL Registrer<TypedOption<int>>;
+template class OZZ_OPTIONS_DLL Registrer<TypedOption<float>>;
+template class OZZ_OPTIONS_DLL Registrer<TypedOption<const char*>>;
 }  // namespace internal
 
 // Construct the parser if no option is registered.

--- a/test/animation/offline/CMakeLists.txt
+++ b/test/animation/offline/CMakeLists.txt
@@ -121,6 +121,7 @@ target_link_libraries(test_fuse_animation_offline
   gtest)
 add_test(NAME test_fuse_animation_offline COMMAND test_fuse_animation_offline)
 set_target_properties(test_fuse_animation_offline PROPERTIES FOLDER "ozz/tests/animation_offline")
+target_compile_definitions(test_fuse_animation_offline PRIVATE OZZ_BUILD_ANIMOFFLINE_LIB)
 
 add_subdirectory(fbx)
 add_subdirectory(gltf)

--- a/test/animation/offline/fbx/CMakeLists.txt
+++ b/test/animation/offline/fbx/CMakeLists.txt
@@ -165,5 +165,6 @@ target_link_libraries(test_fuse_ozz_animation_fbx
   optimized ${FBX_LIBRARIES}
   ozz_animation_offline)
 set_target_properties(test_fuse_ozz_animation_fbx PROPERTIES FOLDER "ozz/tests/animation_offline")
+target_compile_definitions(test_fuse_ozz_animation_fbx PRIVATE OZZ_BUILD_ANIMATIONFBX_LIB)
 
 add_test(NAME test_fuse_ozz_animation_fbx COMMAND test_fuse_ozz_animation_fbx)

--- a/test/animation/offline/tools/CMakeLists.txt
+++ b/test/animation/offline/tools/CMakeLists.txt
@@ -393,6 +393,7 @@ target_link_libraries(test_fuse_ozz_animation_tools
   gtest)
 
 set_target_properties(test_fuse_ozz_animation_tools PROPERTIES FOLDER "ozz/tests/animation_offline")
+target_compile_definitions(test_fuse_ozz_animation_tools PRIVATE OZZ_BUILD_ANIMATIONTOOLS_LIB)
 
 add_test(NAME test_fuse_ozz_animation_tools_no_arg COMMAND test_fuse_ozz_animation_tools)
 set_tests_properties(test_fuse_ozz_animation_tools_no_arg PROPERTIES PASS_REGULAR_EXPRESSION "Required option \"file\" is not specified.")

--- a/test/animation/runtime/CMakeLists.txt
+++ b/test/animation/runtime/CMakeLists.txt
@@ -148,6 +148,7 @@ add_executable(test_fuse_animation
   sampling_job_tests.cc
   ${PROJECT_BINARY_DIR}/src_fused/ozz_animation.cc)
 add_dependencies(test_fuse_animation BUILD_FUSE_ozz_animation)
+target_compile_definitions(test_fuse_animation PRIVATE OZZ_BUILD_ANIMATION_LIB)
 target_link_libraries(test_fuse_animation
   ozz_animation_offline
   gtest)

--- a/test/geometry/runtime/CMakeLists.txt
+++ b/test/geometry/runtime/CMakeLists.txt
@@ -19,3 +19,5 @@ target_link_libraries(test_fuse_geometry
   gtest)
 add_test(NAME test_fuse_geometry COMMAND test_fuse_geometry)
 set_target_properties(test_fuse_geometry PROPERTIES FOLDER "ozz/tests/geometry")
+target_compile_options(test_fuse_geometry PUBLIC /wd4251)
+target_compile_definitions(test_fuse_geometry PRIVATE OZZ_BUILD_GEOMETRY_LIB)


### PR DESCRIPTION
Adds CMake option ozz_build_dll to build as shared libraries (see #59). This option is off by default.

Code that wants to link to ozz as a DLL has to define OZZ_USE_DYNAMIC_LINKING in its own libraries.
When linking directly to the ozz libs through the ozz CMake setup, this is automatically inherited.
To enable DLL export each library has its own define that has to be set, e.g. 'animation' has OZZ_BUILD_ANIMATION_LIB. Only if both that define and OZZ_USE_DYNAMIC_LINKING are set, will the library export symbols. Otherwise the symbols are either imported, or treated like the regular static linking use case.

When building the fused files, defines like OZZ_BUILD_ANIMATION_LIB have to be defined by the user's build system.

This has been tested with VS 2019 x64. The fused sources were used to build a custom ozz DLL. I tested the memory leak issue as well, and it was now gone.

The ozz solution itself fully compiles EXCEPT that I see this error on the BUILD_DATA project and the dump2ozz project:
error MSB6006: "cmd.exe" exited with code -1073741515

I have no idea what that is and how to fix it. It currently prevents me from launching any sample. I also can't run any tests from the solution, because the DLLs are not in the right place.