### PR TITLE
fix conflicting platform.h in glfw.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ The following authors have all licensed their contributions to ozz-animation und
 - Kyle Rocha <kyle@luminawesome.com>
 - Andreas Streichardt <andreas.streichardt@gmail.com>
 - Chen Junjie <kitchen.gz.020@gmail.com>
+- James W. Walker <jw@jwwalker.com>

--- a/extern/glfw/lib/internal.h
+++ b/extern/glfw/lib/internal.h
@@ -89,8 +89,13 @@ typedef struct {
 // glfw.h)
 //------------------------------------------------------------------------
 
-#include "platform.h"
-
+#if __APPLE__
+	#include "cocoa/platform.h"
+#elif WIN32
+	#include "win32/platform.h"
+#else
+	#include "x11/platform.h"
+#endif
 
 //------------------------------------------------------------------------
 // Parameters relating to the creation of the context and window but not


### PR DESCRIPTION
I was getting a compile error on Mac, due to confusion between the platform.h in GLFW and ozz/base/platform.h.