### PR TITLE
Copy name to output name for additive_builder.

### DIFF
--- a/src/animation/offline/additive_animation_builder.cc
+++ b/src/animation/offline/additive_animation_builder.cc
@@ -89,6 +89,7 @@ bool AdditiveAnimationBuilder::operator()(const RawAnimation& _input,
   }
 
   // Rebuilds output animation.
+  _output->name = _input.name;
   _output->duration = _input.duration;
   _output->tracks.resize(_input.tracks.size());
 
@@ -143,6 +144,7 @@ bool AdditiveAnimationBuilder::operator()(
   }
 
   // Rebuilds output animation.
+  _output->name = _input.name;
   _output->duration = _input.duration;
   _output->tracks.resize(_input.tracks.size());
 


### PR DESCRIPTION
I noticed that gltf2ozz was outputting additive files with empty filename after I fetched latest changes.
I.e. a configuration like this was producing files as "_additive.ozz" for each animation
```

      "clip" : "*Pose*",
      "filename" : "*_additive.ozz",
      "raw" : false,
      "optimize" : true,
      "additive": true,
      "additive_reference": "skeleton",
```