### PR TITLE
Added per-instance allocator support for animation.

### DIFF
--- a/include/ozz/animation/runtime/animation.h
+++ b/include/ozz/animation/runtime/animation.h
@@ -37,6 +37,9 @@ namespace io {
 class IArchive;
 class OArchive;
 }  // namespace io
+namespace memory {
+    class Allocator;
+}  // namespace memory
 namespace animation {
 
 // Forward declares the AnimationBuilder, used to instantiate an Animation.
@@ -62,6 +65,9 @@ class Animation {
  public:
   // Builds a default animation.
   Animation();
+
+  // Builds an animation with a custom allocator
+  Animation(ozz::memory::Allocator* _customalloc);
 
   // Declares the public non-virtual destructor.
   ~Animation();
@@ -111,6 +117,8 @@ class Animation {
   void Allocate(size_t _name_len, size_t _translation_count,
                 size_t _rotation_count, size_t _scale_count);
   void Deallocate();
+
+  ozz::memory::Allocator* allocator_;
 
   // Duration of the animation clip.
   float duration_;

--- a/src/animation/runtime/animation.cc
+++ b/src/animation/runtime/animation.cc
@@ -44,7 +44,9 @@ namespace ozz {
 
 namespace animation {
 
-Animation::Animation() : duration_(0.f), num_tracks_(0), name_(nullptr) {}
+Animation::Animation() : allocator_(memory::default_allocator()), duration_(0.f), num_tracks_(0), name_(nullptr) {}
+
+Animation::Animation(ozz::memory::Allocator* _customalloc) : allocator_(_customalloc), duration_(0.f), num_tracks_(0), name_(nullptr) {}
 
 Animation::~Animation() { Deallocate(); }
 
@@ -65,7 +67,7 @@ void Animation::Allocate(size_t _name_len, size_t _translation_count,
                              _translation_count * sizeof(Float3Key) +
                              _rotation_count * sizeof(QuaternionKey) +
                              _scale_count * sizeof(Float3Key);
-  span<char> buffer = {static_cast<char*>(memory::default_allocator()->Allocate(
+  span<char> buffer = {static_cast<char*>(allocator_->Allocate(
                            buffer_size, alignof(Float3Key))),
                        buffer_size};
 
@@ -83,7 +85,7 @@ void Animation::Allocate(size_t _name_len, size_t _translation_count,
 }
 
 void Animation::Deallocate() {
-  memory::default_allocator()->Deallocate(
+  allocator_->Deallocate(
       as_writable_bytes(translations_).data());
 
   name_ = nullptr;


### PR DESCRIPTION
Using ozz in production runtime, some animations (like narrative) benefit from using a different allocator (say, linear) versus the rest of gameplay animations. This patch allows each animation to have its own allocator instance, which can be crucial for preventing stutter in gameplay --> narrative --> gameplay scenarios.