### PR TITLE
Fix incorrect transforms in gltf2ozz

### DIFF
--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -362,12 +362,35 @@ CreateTranslationRestPoseKey(const tinygltf::Node& _node) {
   ozz::animation::offline::RawAnimation::TranslationKey key;
   key.time = 0.0f;
 
-  if (_node.translation.empty()) {
-    key.value = ozz::math::Float3::zero();
-  } else {
+  if (!_node.translation.empty()) {
     key.value = ozz::math::Float3(static_cast<float>(_node.translation[0]),
                                   static_cast<float>(_node.translation[1]),
                                   static_cast<float>(_node.translation[2]));
+  } else if (_node.matrix.empty()) {
+    // Extract translation from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::Store3PtrU(translation, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Float3::zero();
   }
 
   return key;
@@ -378,13 +401,36 @@ ozz::animation::offline::RawAnimation::RotationKey CreateRotationRestPoseKey(
   ozz::animation::offline::RawAnimation::RotationKey key;
   key.time = 0.0f;
 
-  if (_node.rotation.empty()) {
-    key.value = ozz::math::Quaternion::identity();
-  } else {
+  if (!_node.rotation.empty()) {
     key.value = ozz::math::Quaternion(static_cast<float>(_node.rotation[0]),
                                       static_cast<float>(_node.rotation[1]),
                                       static_cast<float>(_node.rotation[2]),
                                       static_cast<float>(_node.rotation[3]));
+  } else if (_node.matrix.empty()) {
+    // Extract rotation from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::StorePtrU(rotation, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Quaternion::identity();
   }
   return key;
 }
@@ -394,12 +440,35 @@ ozz::animation::offline::RawAnimation::ScaleKey CreateScaleRestPoseKey(
   ozz::animation::offline::RawAnimation::ScaleKey key;
   key.time = 0.0f;
 
-  if (_node.scale.empty()) {
-    key.value = ozz::math::Float3::one();
-  } else {
+  if (!_node.scale.empty()) {
     key.value = ozz::math::Float3(static_cast<float>(_node.scale[0]),
                                   static_cast<float>(_node.scale[1]),
                                   static_cast<float>(_node.scale[2]));
+  } else if (_node.matrix.empty()) {
+    // Extract scale from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::Store3PtrU(scale, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Float3::one();
   }
   return key;
 }

--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -358,23 +358,23 @@ bool SampleChannel(const tinygltf::Model& _model,
 }
 
 // Converts a glTF matrix to an ozz::math::Float4x4 matrix.
-ozz::math::Float4x4 ToMatrix(const std::vector<double> gltfMatrix) {
-  return {{ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[0]),
-                                        static_cast<float>(gltfMatrix[1]),
-                                        static_cast<float>(gltfMatrix[2]),
-                                        static_cast<float>(gltfMatrix[3])),
-           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[4]),
-                                        static_cast<float>(gltfMatrix[5]),
-                                        static_cast<float>(gltfMatrix[6]),
-                                        static_cast<float>(gltfMatrix[7])),
-           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[8]),
-                                        static_cast<float>(gltfMatrix[9]),
-                                        static_cast<float>(gltfMatrix[10]),
-                                        static_cast<float>(gltfMatrix[11])),
-           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[12]),
-                                        static_cast<float>(gltfMatrix[13]),
-                                        static_cast<float>(gltfMatrix[14]),
-                                        static_cast<float>(gltfMatrix[15]))}};
+ozz::math::Float4x4 ToMatrix(const std::vector<double>& _gltf_matrix) {
+  return {{ozz::math::simd_float4::Load(static_cast<float>(_gltf_matrix[0]),
+                                        static_cast<float>(_gltf_matrix[1]),
+                                        static_cast<float>(_gltf_matrix[2]),
+                                        static_cast<float>(_gltf_matrix[3])),
+           ozz::math::simd_float4::Load(static_cast<float>(_gltf_matrix[4]),
+                                        static_cast<float>(_gltf_matrix[5]),
+                                        static_cast<float>(_gltf_matrix[6]),
+                                        static_cast<float>(_gltf_matrix[7])),
+           ozz::math::simd_float4::Load(static_cast<float>(_gltf_matrix[8]),
+                                        static_cast<float>(_gltf_matrix[9]),
+                                        static_cast<float>(_gltf_matrix[10]),
+                                        static_cast<float>(_gltf_matrix[11])),
+           ozz::math::simd_float4::Load(static_cast<float>(_gltf_matrix[12]),
+                                        static_cast<float>(_gltf_matrix[13]),
+                                        static_cast<float>(_gltf_matrix[14]),
+                                        static_cast<float>(_gltf_matrix[15]))}};
 }
 
 ozz::animation::offline::RawAnimation::TranslationKey

--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -383,7 +383,7 @@ bool FromNodeMatrix(const tinygltf::Node& _node,
                     ozz::math::Float3* _scale) {
   const ozz::math::Float4x4 matrix = ToMatrix(_node.matrix);
   ozz::math::SimdFloat4 translation, rotation, scale;
-  if (ToAffine(matrix, &translation, &rotation, &scale)) {
+  if (!ToAffine(matrix, &translation, &rotation, &scale)) {
     ozz::log::Err() << "Failed to extract transformation from node \""
                     << _node.name << "\"." << std::endl;
     return false;

--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -357,6 +357,26 @@ bool SampleChannel(const tinygltf::Model& _model,
   return valid;
 }
 
+// Converts a glTF matrix to an ozz::math::Float4x4 matrix.
+ozz::math::Float4x4 ToMatrix(const std::vector<double> gltfMatrix) {
+  return {{ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[0]),
+                                        static_cast<float>(gltfMatrix[1]),
+                                        static_cast<float>(gltfMatrix[2]),
+                                        static_cast<float>(gltfMatrix[3])),
+           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[4]),
+                                        static_cast<float>(gltfMatrix[5]),
+                                        static_cast<float>(gltfMatrix[6]),
+                                        static_cast<float>(gltfMatrix[7])),
+           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[8]),
+                                        static_cast<float>(gltfMatrix[9]),
+                                        static_cast<float>(gltfMatrix[10]),
+                                        static_cast<float>(gltfMatrix[11])),
+           ozz::math::simd_float4::Load(static_cast<float>(gltfMatrix[12]),
+                                        static_cast<float>(gltfMatrix[13]),
+                                        static_cast<float>(gltfMatrix[14]),
+                                        static_cast<float>(gltfMatrix[15]))}};
+}
+
 ozz::animation::offline::RawAnimation::TranslationKey
 CreateTranslationRestPoseKey(const tinygltf::Node& _node) {
   ozz::animation::offline::RawAnimation::TranslationKey key;
@@ -368,23 +388,8 @@ CreateTranslationRestPoseKey(const tinygltf::Node& _node) {
                                   static_cast<float>(_node.translation[2]));
   } else if (!_node.matrix.empty()) {
     // Extract translation from the matrix
-    const ozz::math::Float4x4 matrix = {
-        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
-                                      static_cast<float>(_node.matrix[1]),
-                                      static_cast<float>(_node.matrix[2]),
-                                      static_cast<float>(_node.matrix[3])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
-                                      static_cast<float>(_node.matrix[5]),
-                                      static_cast<float>(_node.matrix[6]),
-                                      static_cast<float>(_node.matrix[7])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
-                                      static_cast<float>(_node.matrix[9]),
-                                      static_cast<float>(_node.matrix[10]),
-                                      static_cast<float>(_node.matrix[11])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
-                                      static_cast<float>(_node.matrix[13]),
-                                      static_cast<float>(_node.matrix[14]),
-                                      static_cast<float>(_node.matrix[15]))}};
+    const ozz::math::Float4x4 matrix = ToMatrix(_node.matrix);
+    
     ozz::math::SimdFloat4 translation, rotation, scale;
     if (ToAffine(matrix, &translation, &rotation, &scale)) {
       ozz::math::Store3PtrU(translation, &key.value.x);
@@ -408,23 +413,8 @@ ozz::animation::offline::RawAnimation::RotationKey CreateRotationRestPoseKey(
                                       static_cast<float>(_node.rotation[3]));
   } else if (!_node.matrix.empty()) {
     // Extract rotation from the matrix
-    const ozz::math::Float4x4 matrix = {
-        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
-                                      static_cast<float>(_node.matrix[1]),
-                                      static_cast<float>(_node.matrix[2]),
-                                      static_cast<float>(_node.matrix[3])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
-                                      static_cast<float>(_node.matrix[5]),
-                                      static_cast<float>(_node.matrix[6]),
-                                      static_cast<float>(_node.matrix[7])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
-                                      static_cast<float>(_node.matrix[9]),
-                                      static_cast<float>(_node.matrix[10]),
-                                      static_cast<float>(_node.matrix[11])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
-                                      static_cast<float>(_node.matrix[13]),
-                                      static_cast<float>(_node.matrix[14]),
-                                      static_cast<float>(_node.matrix[15]))}};
+    const ozz::math::Float4x4 matrix = ToMatrix(_node.matrix);
+    
     ozz::math::SimdFloat4 translation, rotation, scale;
     if (ToAffine(matrix, &translation, &rotation, &scale)) {
       ozz::math::StorePtrU(rotation, &key.value.x);
@@ -446,23 +436,8 @@ ozz::animation::offline::RawAnimation::ScaleKey CreateScaleRestPoseKey(
                                   static_cast<float>(_node.scale[2]));
   } else if (!_node.matrix.empty()) {
     // Extract scale from the matrix
-    const ozz::math::Float4x4 matrix = {
-        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
-                                      static_cast<float>(_node.matrix[1]),
-                                      static_cast<float>(_node.matrix[2]),
-                                      static_cast<float>(_node.matrix[3])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
-                                      static_cast<float>(_node.matrix[5]),
-                                      static_cast<float>(_node.matrix[6]),
-                                      static_cast<float>(_node.matrix[7])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
-                                      static_cast<float>(_node.matrix[9]),
-                                      static_cast<float>(_node.matrix[10]),
-                                      static_cast<float>(_node.matrix[11])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
-                                      static_cast<float>(_node.matrix[13]),
-                                      static_cast<float>(_node.matrix[14]),
-                                      static_cast<float>(_node.matrix[15]))}};
+    const ozz::math::Float4x4 matrix = ToMatrix(_node.matrix);
+    
     ozz::math::SimdFloat4 translation, rotation, scale;
     if (ToAffine(matrix, &translation, &rotation, &scale)) {
       ozz::math::Store3PtrU(scale, &key.value.x);
@@ -479,23 +454,8 @@ bool CreateNodeTransform(const tinygltf::Node& _node,
   *_transform = ozz::math::Transform::identity();
 
   if (!_node.matrix.empty()) {
-    const ozz::math::Float4x4 matrix = {
-        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
-                                      static_cast<float>(_node.matrix[1]),
-                                      static_cast<float>(_node.matrix[2]),
-                                      static_cast<float>(_node.matrix[3])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
-                                      static_cast<float>(_node.matrix[5]),
-                                      static_cast<float>(_node.matrix[6]),
-                                      static_cast<float>(_node.matrix[7])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
-                                      static_cast<float>(_node.matrix[9]),
-                                      static_cast<float>(_node.matrix[10]),
-                                      static_cast<float>(_node.matrix[11])),
-         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
-                                      static_cast<float>(_node.matrix[13]),
-                                      static_cast<float>(_node.matrix[14]),
-                                      static_cast<float>(_node.matrix[15]))}};
+    const ozz::math::Float4x4 matrix = ToMatrix(_node.matrix);
+    
     ozz::math::SimdFloat4 translation, rotation, scale;
     if (ToAffine(matrix, &translation, &rotation, &scale)) {
       ozz::math::Store3PtrU(translation, &_transform->translation.x);

--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -366,7 +366,7 @@ CreateTranslationRestPoseKey(const tinygltf::Node& _node) {
     key.value = ozz::math::Float3(static_cast<float>(_node.translation[0]),
                                   static_cast<float>(_node.translation[1]),
                                   static_cast<float>(_node.translation[2]));
-  } else if (_node.matrix.empty()) {
+  } else if (!_node.matrix.empty()) {
     // Extract translation from the matrix
     const ozz::math::Float4x4 matrix = {
         {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
@@ -406,7 +406,7 @@ ozz::animation::offline::RawAnimation::RotationKey CreateRotationRestPoseKey(
                                       static_cast<float>(_node.rotation[1]),
                                       static_cast<float>(_node.rotation[2]),
                                       static_cast<float>(_node.rotation[3]));
-  } else if (_node.matrix.empty()) {
+  } else if (!_node.matrix.empty()) {
     // Extract rotation from the matrix
     const ozz::math::Float4x4 matrix = {
         {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
@@ -444,7 +444,7 @@ ozz::animation::offline::RawAnimation::ScaleKey CreateScaleRestPoseKey(
     key.value = ozz::math::Float3(static_cast<float>(_node.scale[0]),
                                   static_cast<float>(_node.scale[1]),
                                   static_cast<float>(_node.scale[2]));
-  } else if (_node.matrix.empty()) {
+  } else if (!_node.matrix.empty()) {
     // Extract scale from the matrix
     const ozz::math::Float4x4 matrix = {
         {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),


### PR DESCRIPTION
Since gltf2ozz considers the entire scene graph as a skeleton if no skins are defined in the glTF file, we can encounter (non-animated) nodes using `matrix` instead of `translation`, `rotation` and `scale` for their transformations while parsing all nodes. These were considered "without a transform", leading to incorrect results.

An example of this behavior can be seen, if you have a glTF viewer using ozz-animation, on the following model: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/VC.

In that model, the "container" node, "node_0", has a `matrix` transform which gets ignored by gltf2ozz, making all child nodes not respect the parent's transform. This leads to all animated nodes being incorrectly rotated and scaled.

Importing the VC model in Blender and exporting it without making any changes fortunately replaces all matrices with translations, rotations and scales, which allows for an easy comparison.