### PR TITLE
Fixes gcc11 c++20 compilation error

### DIFF
--- a/include/ozz/base/containers/std_allocator.h
+++ b/include/ozz/base/containers/std_allocator.h
@@ -49,7 +49,7 @@ class StdAllocator {
   StdAllocator(const StdAllocator&) noexcept {}
 
   template <class _Other>
-  StdAllocator<value_type>(const StdAllocator<_Other>&) noexcept {}
+  StdAllocator(const StdAllocator<_Other>&) noexcept {}
 
   template <class _Other>
   struct rebind {


### PR DESCRIPTION
```
3rd/ozz-animation/include/ozz/base/containers/std_allocator.h:52:28: error: expected unqualified-id before 'const'
   52 |   StdAllocator<value_type>(const StdAllocator<_Other>&) noexcept {}
      |                            ^~~~~
3rd/ozz-animation/include/ozz/base/containers/std_allocator.h:52:28: error: expected ')' before 'const'
   52 |   StdAllocator<value_type>(const StdAllocator<_Other>&) noexcept {}
      |                           ~^~~~~
      |                            )
```