### PR TITLE
Additive rotation fix

### DIFF
--- a/src/animation/offline/additive_animation_builder.cc
+++ b/src/animation/offline/additive_animation_builder.cc
@@ -63,7 +63,7 @@ math::Float3 MakeDeltaTranslation(const math::Float3& _reference,
 
 math::Quaternion MakeDeltaRotation(const math::Quaternion& _reference,
                                    const math::Quaternion& _value) {
-  return _value * Conjugate(_reference);
+  return Conjugate(_reference) * _value;
 }
 
 math::Float3 MakeDeltaScale(const math::Float3& _reference,

--- a/src/animation/runtime/blending_job.cc
+++ b/src/animation/runtime/blending_job.cc
@@ -129,7 +129,7 @@ namespace {
     const math::SoaQuaternion interp_quat = {                                \
         rotation.x * _simd_weight, rotation.y * _simd_weight,                \
         rotation.z * _simd_weight, (rotation.w - one) * _simd_weight + one}; \
-    _out.rotation = NormalizeEst(interp_quat) * _out.rotation;               \
+    _out.rotation = _out.rotation * NormalizeEst(interp_quat);               \
     _out.scale =                                                             \
         _out.scale * (one_minus_weight_f3 + (_in.scale * _simd_weight));     \
   } while (void(0), 0)
@@ -147,7 +147,7 @@ namespace {
     const math::SoaQuaternion interp_quat = {                                  \
         rotation.x * _simd_weight, rotation.y * _simd_weight,                  \
         rotation.z * _simd_weight, (rotation.w - one) * _simd_weight + one};   \
-    _out.rotation = Conjugate(NormalizeEst(interp_quat)) * _out.rotation;      \
+    _out.rotation = _out.rotation * Conjugate(NormalizeEst(interp_quat));      \
     const math::SoaFloat3 rcp_scale = {                                        \
         math::RcpEst(math::MAdd(_in.scale.x, _simd_weight, one_minus_weight)), \
         math::RcpEst(math::MAdd(_in.scale.y, _simd_weight, one_minus_weight)), \


### PR DESCRIPTION
Quaternion multiplication rotates lhs by the rhs, but the current implementation of additive rotations on the blending job had the operands swapped.

Side note: When creating an additive animation the operands are in the right order https://github.com/guillaumeblanc/ozz-animation/blob/master/src/animation/offline/additive_animation_builder.cc#L66