### PR TITLE
Fixes deprecated implicit copy warning

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@ The following authors have all licensed their contributions to ozz-animation und
 - Kota Iguchi <developer@infosia.co.jp>
 - Mikołaj Siedlarek <mikolaj@siedlarek.net>
 - Paul Gruenbacher <pgruenbacher@gmail.com>
+- Christophe Meyer <christophe.meyer.pro@gmail.com>

--- a/include/ozz/base/span.h
+++ b/include/ozz/base/span.h
@@ -61,6 +61,9 @@ struct span {
   // elements.
   span(_Ty* _begin, size_t _size) : data_(_begin), size_(_size) {}
 
+  // Copy constructor.
+  span(const span& _other) = default;
+
   // Copy operator.
   void operator=(const span& _other) {
     data_ = _other.data_;

--- a/test/base/containers/intrusive_list_tests.cc
+++ b/test/base/containers/intrusive_list_tests.cc
@@ -645,10 +645,9 @@ class is_to_be_removed {
  public:
   explicit is_to_be_removed(int _which) : which_(_which) {}
   bool operator()(typename _List::const_reference) { return which_-- == 0; }
+  void operator=(const is_to_be_removed&) = delete;
 
  private:
-  void operator=(const is_to_be_removed&);
-
   int which_;
 };
 


### PR DESCRIPTION
Hi and thanks for this wonderful library!  I'm proposing a fix for some compilation warnings.

Compiling with warning flag `-Wdeprecated-copy` (part of `-Wextra`) produced this type of warning on clang and gcc:
```
/home/cmey/Code/cpp/ozz-animation/include/ozz/base/span.h:65:8: warning: definition of implicit copy constructor for 'span<const ozz::animation::Float3Key>' is deprecated because it has a user-provided copy assignment operator [-Wdeprecated-copy-with-user-provided-copy]
  void operator=(const span& _other) {
       ^
/home/cmey/Code/cpp/ozz-animation/include/ozz/animation/runtime/animation.h:92:48: note: in implicit copy constructor for 'ozz::span<const ozz::animation::Float3Key>' first required here
  span<const Float3Key> translations() const { return translations_; }
```

Easy steps to repro on `develop`:
```
cmake -D CMAKE_CXX_FLAGS="-Wdeprecated-copy" ../
cmake --build .
```

I saw 2 occurrences of the warning so there are 2 changes:
- The first in `span.h`, where I've added the explicit default copy constructor (a copy operator was already implemented). It turns out the copy constructor is used, because explicitly disabling it with `= delete` produces errors.
- The second in `intrusive_list_tests.cc`, where I've simply updated the disabling of the copy assignment operator to the more modern way. This way there no longer is a user-provided copy assignment operator, which appeases the warning.

This clears the warnings reported above.

I've followed the [Contributing guidelines](https://github.com/guillaumeblanc/ozz-animation/blob/7fd3642f170f8ecaa31e911267e838eaf149b462/CONTRIBUTING.md):
- [x] Ran `clang-format` on the touched files
- [x] `ctest` passes locally
- [x] Appended name to AUTHORS.md

Hope this helps!