### PR TITLE
Include the C++ standard library in the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation and samples are available from [ozz-animation website](http://guil
 Supported platforms
 -------------------
 
-Ozz is tested on Linux, Mac OS and Windows, for x86, x86-64 and ARM architectures. The run-time code (ozz_base, ozz_animation, ozz_geometry) depends only on c++11, the standard CRT and has no OS specific code, portability to any other platform shouldn't be an issue.
+Ozz is tested on Linux, Mac OS and Windows, for x86, x86-64 and ARM architectures. The run-time code (ozz_base, ozz_animation, ozz_geometry) depends only on c++11, on the C and the C++ standard libraries, and has no OS specific code. Portability to any other platform shouldn't be an issue.
 
 Samples, tools and tests depend on external libraries (glfw, tinygltf, Fbx SDK, jsoncpp, gtest, ...), which could limit portability.
 


### PR DESCRIPTION
The README menitoned only the C runtime.
However, in Unix systems, you can link C++ binaries to libc without linking a C++ standard library, but this does not work for ozz. So, this commit makes it more clear that a standard C++ library is required, too.

Normally, you could also be more precise about _which_ implementations you support (e.g., MSVC >= some version, mingw, glibc, musl, libstdc++, libc++, etc...), but I preferred not to. I think that ozz should work with all of them, since from what I've seen it uses only standard code.

Solves #165.