### PR TITLE
make the dll_copy generated file a PRIVATE target_source

### DIFF
--- a/build-utils/cmake/shared_library.cmake
+++ b/build-utils/cmake/shared_library.cmake
@@ -43,6 +43,6 @@ function(target_copy_shared_libraries _TARGET)
       VERBATIM)
 
       # This allows to create a dependency with the command above, so command is executed again when target is built AND a DLL changed
-    target_sources(${_TARGET} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/${_TARGET}_dll_copy")
+    target_sources(${_TARGET} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${_TARGET}_dll_copy")
   endif()
 endfunction()


### PR DESCRIPTION
Hi, thanks for the excellent library! I tried to use it in my project with `FetchContent` but got an error when installing saying that the `dll_copy` target source is inside the binary dir.  By changing it to `PRIVATE` it seems to work, but I'm no CMake expert so maybe this solution has other effects, but I couldn't find any. I think it's better explained [here](https://stackoverflow.com/questions/60736689/cmake-target-sources-and-install).