### PR TITLE
Make Stream's destructor public.

### DIFF
--- a/include/ozz/base/io/stream.h
+++ b/include/ozz/base/io/stream.h
@@ -74,11 +74,11 @@ class OZZ_BASE_DLL Stream {
   // Returns the current size of the stream.
   virtual size_t Size() const = 0;
 
- protected:
-  Stream() {}
-
   // Required virtual destructor.
   virtual ~Stream() {}
+
+ protected:
+  Stream() {}
 
  private:
   Stream(const Stream&);


### PR DESCRIPTION
This commit makes `ozz::io::Stream`'s destructor public.

The use case is having a function that returns a generic `std::unique_ptr<ozz::io::Stream>` which will be automatically destructed when the consumer is done with it without having to make assumption on the stream type.

If the constructor is `protected`/`private`, also `std::unique_ptr` cannot access it and the program fails to build.